### PR TITLE
Windows default backend set to multipass

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -68,6 +68,8 @@ func serverInit(cmd *cobra.Command, args []string) {
 			backendType = "lxd"
 		case "darwin":
 			backendType = "multipass"
+		case "windows":
+			backendType = "multipass"
 		default:
 			err := deleteLocalDirectories(userHome)
 			if err != nil {


### PR DESCRIPTION
Currently, when `brave init` is called without arguments on Windows the command fails and prints a "OS not supported" message.

Instead, it would make sense to set the backend to multipass by default and proceed with the initialization.