### PR TITLE
Ensure files are closed by Bravetools before removing/renaming

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -103,10 +103,10 @@ func (bh *BraveHost) ImportLocalImage(name string) error {
 	if err != nil {
 		return errors.New(err.Error())
 	}
+	defer f.Close()
 
 	_, err = f.WriteString(imageHash)
 	if err != nil {
-		f.Close()
 		return errors.New(err.Error())
 	}
 
@@ -165,10 +165,10 @@ func (bh *BraveHost) ListLocalImages() error {
 						if err != nil {
 							return errors.New(err.Error())
 						}
+						defer f.Close()
 
 						_, err = f.WriteString(imageHash)
 						if err != nil {
-							f.Close()
 							return errors.New(err.Error())
 						}
 
@@ -662,12 +662,13 @@ func (bh *BraveHost) BuildUnit(bravefile *shared.Bravefile) error {
 	if err != nil {
 		return errors.New(err.Error())
 	}
+	defer f.Close()
 
 	_, err = f.WriteString(imageHash)
 	if err != nil {
-		f.Close()
 		return errors.New(err.Error())
 	}
+	f.Close()
 
 	err = shared.CopyFile(localImageFile, home+shared.ImageStore+localImageFile)
 	if err != nil {

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -113,6 +113,7 @@ func AddRemote(braveHost *BraveHost) error {
 	if err != nil {
 		return err
 	}
+	defer certOut.Close()
 
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
 	certOut.Close()
@@ -744,6 +745,9 @@ func ExportImage(fingerprint string, name string, remote Remote) error {
 	if err != nil {
 		return err
 	}
+	// Implicitly clean up temporary file on err
+	// Defers are resolved LIFO - below ensures file closed before deletion
+	defer os.Remove(targetRootfs)
 	defer destRootfs.Close()
 
 	req := lxd.ImageFileRequest{
@@ -753,8 +757,8 @@ func ExportImage(fingerprint string, name string, remote Remote) error {
 
 	resp, err := lxdServer.GetImageFile(fingerprint, req)
 	if err != nil {
+		dest.Close()
 		os.Remove(name)
-		os.Remove(targetRootfs)
 		return err
 	}
 
@@ -771,12 +775,14 @@ func ExportImage(fingerprint string, name string, remote Remote) error {
 		return err
 	}
 
+	dest.Close()
+	destRootfs.Close()
+
 	// Cleanup
 	if resp.RootfsSize == 0 {
 		err := os.Remove(targetRootfs)
 		if err != nil {
 			os.Remove(name)
-			os.Remove(targetRootfs)
 			return err
 		}
 	}


### PR DESCRIPTION
1) Explicitly close files after writing to them, before performing further operations on the file (e.g. remove, rename).
This fixes issues encountered in Windows while building new images. (https://github.com/bravetools/bravetools/issues/8)

2) Formalize use of double close pattern for os.File to ensure files are closed in case of err
https://github.com/golang/go/issues/20705

