### PR TITLE
address #49

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -394,7 +394,7 @@ func cleanUnusedStoragePool(name string, remote Remote) {
 // addIPRules adds firewall rule to the host iptable
 func addIPRules(ct string, hostPort string, ctPort string, bh *BraveHost) error {
 
-	name := ct + "-proxy-" + hostPort + ":" + ctPort
+	name := ct + "-proxy-" + hostPort + "-" + ctPort
 
 	var config = make(map[string]string)
 


### PR DESCRIPTION
This is a backward-compatible change to address a bug introduced by https://github.com/lxc/lxd/pull/9946

The main issue is around name of a proxy device. Historically, we use `:` in proxy device names. This is now replaced by `-` to avoid the incompatibility error when trying to delete units.