### PR TITLE
Fix docs to refer to "local" images rather than "private" images

### DIFF
--- a/docs/docs/bravefile.md
+++ b/docs/docs/bravefile.md
@@ -26,7 +26,7 @@ base:
 Three types of image locations are supported:
 
 1. ``public`` - specifies that images are to be pulled from the [linuxcontainers](https://images.linuxcontainers.org) repository. Accepted image name syntax is ``Distribution/Release/Architecture``.
-2. ``private`` - images stored locally. Naming follows the convention ``image-name-version``.
+2. ``local`` - images stored locally. Naming follows the convention ``image-name-version``.
 3. ``github`` - images that can be built and imported on the fly from Bravefiles stored inside GitHub directories. Naming convention is ``username/repository/directory``. Bravetools will search for a Bravefiles inside the ``/directory`` location.
 
 In cases where Bravefiles are ingested from GitHub, a local copy of the resulting image will be kept. The local image copy will be re-used next time you run ``brave build``.

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -577,13 +577,13 @@ func (bh *BraveHost) BuildUnit(bravefile *shared.Bravefile) error {
 		if err != nil {
 			log.Fatal(err)
 		}
-	default:
-		if bravefile.Base.Location == "local" {
-			err = importLocal(bravefile, bh.Remote)
-			if err != nil {
-				log.Fatal(err)
-			}
+	case "local":
+		err = importLocal(bravefile, bh.Remote)
+		if err != nil {
+			log.Fatal(err)
 		}
+	default:
+		return fmt.Errorf("base image location %q not supported", bravefile.Base.Location)
 	}
 
 	pMan := bravefile.SystemPackages.Manager


### PR DESCRIPTION
The docs refer to a location type "private" which does not exist. When an invalid location is supplied, a helpful error message will be returned