### PR TITLE
Rename function BuildUnit to BuildImage 

### DIFF
--- a/commands/base.go
+++ b/commands/base.go
@@ -59,7 +59,7 @@ func buildBase(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	err = host.BuildUnit(bravefile)
+	err = host.BuildImage(bravefile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/build.go
+++ b/commands/build.go
@@ -39,7 +39,7 @@ func build(cmd *cobra.Command, args []string) {
 		log.Fatal("Failed to load Bravefile: ", err)
 	}
 
-	err = host.BuildUnit(bravefile)
+	err = host.BuildImage(bravefile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -125,7 +125,7 @@ func importGitHub(bravefile *shared.Bravefile, bh *BraveHost) error {
 	remoteServiceName := remoteBravefile.PlatformService.Name + "-" + remoteBravefile.PlatformService.Version
 
 	if _, err := os.Stat(filepath.Join(imageLocation, remoteServiceName+".tar.gz")); os.IsNotExist(err) {
-		err = bh.BuildUnit(remoteBravefile)
+		err = bh.BuildImage(remoteBravefile)
 		if err != nil {
 			return err
 		}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -525,8 +525,8 @@ func (bh *BraveHost) DeleteUnit(name string) error {
 	return nil
 }
 
-// BuildUnit creates unit based on Bravefile
-func (bh *BraveHost) BuildUnit(bravefile *shared.Bravefile) error {
+// BuildImage creates an image based on Bravefile
+func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 	var fingerprint string
 
 	if strings.ContainsAny(bravefile.PlatformService.Name, "/_. !@£$%^&*(){}:;`~,?") {


### PR DESCRIPTION
This would better represent what is actually happening conceptually - an image is being built, from which units can be deployed.