### PR TITLE
Return image fingerprint when building from base local/github images

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -571,7 +571,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			log.Fatal(err)
 		}
 	case "github":
-		err = importGitHub(bravefile, bh)
+		fingerprint, err = importGitHub(bravefile, bh)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -581,7 +581,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			log.Fatal(err)
 		}
 	case "local":
-		err = importLocal(bravefile, bh.Remote)
+		fingerprint, err = importLocal(bravefile, bh.Remote)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Importing base images from public LXD servers set the fingerprint string, but other paths in the code left the image fingerprint at its default value (""), causing it to be impossible to delete image by fingerprint later. This would happen when the image base location was set to local. To address the problem, all import functions also return the image fingerprint when done.

This change allows for proper cleanup of images after build completion or in event of failure.

Also added cleanup of local image if `importLocal` fails to start a unit.

Together these should helps address problems caused by LXD images hanging around after a build, preventing future builds that attempt to use that alias.