### PR TITLE
Remove attempts to remove LXD image of same name when deleting a unit

### DIFF
--- a/commands/remove.go
+++ b/commands/remove.go
@@ -39,10 +39,5 @@ func remove(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-
-		err = host.DeleteImageByName(args[0])
-		if err != nil {
-			log.Fatal(err)
-		}
 	}
 }


### PR DESCRIPTION
When calling the `remove` command without the `-i` flag, it is expected that the command would delete units instead of images. However, the command also attempts to remove any host LXD containers with the same name as the unit after deleting the unit.

In most cases, that image will not exist - in theory temporary images should have been cleaned up during build. This leads to "Image alias not found" errors.

Even if there was an issue with leftover images needing to be cleaned up, this function would only help if the unit name and the image name matched, which isn't necessarily the case.