### PR TITLE
Fix doc typos

### DIFF
--- a/docs/docs/cli/brave_base.md
+++ b/docs/docs/cli/brave_base.md
@@ -16,7 +16,7 @@ brave base DISTRIBUTION/RELEASE/ARCH
 
 ## Description
 
-Bravetools can import base images either from LXD Image Server (https://images.linuxcontainers.org) or from Bravefiles stored in public GitHub repositories. This creates an efficient way of levereging multiple pre-built images to speed up creation of a bespoke system container.
+Bravetools can import base images either from LXD Image Server (https://images.linuxcontainers.org) or from Bravefiles stored in public GitHub repositories. This creates an efficient way of leveraging multiple pre-built images to speed up creation of a bespoke system container.
 
 ### Pulling from LXD Image server
 

--- a/docs/docs/cli/brave_configure.md
+++ b/docs/docs/cli/brave_configure.md
@@ -16,7 +16,7 @@ brave configure
 
 ## Description
 
-Bravetools reads configuration specifications from ~/.bravetools/config.yaml and configures host accordingly
+Bravetools reads configuration specifications from ~/.bravetools/config.yml and configures host accordingly
 
 ## Options
 

--- a/docs/docs/cli/brave_init.md
+++ b/docs/docs/cli/brave_init.md
@@ -30,9 +30,9 @@ On Mac and Windows platforms:
 
 On Linux distributions:
 
-* Set up a new LXD profile `brave`
-* Create a new LXD bridge `bravebr0`
-* Create a new storage pool `brave-TIMESTAMP`
+* Set up a new LXD profile `$USER`
+* Create a new LXD bridge `$USERbr0`
+* Create a new storage pool `$USER-TIMESTAMP`
 
 These steps ensure that Bravetools establishes a connection with LXD server and runs a self-contained LXD environment that doesn't interfere with any potentially existing profiles and LXD bridges.
 

--- a/docs/docs/cli/brave_mount.md
+++ b/docs/docs/cli/brave_mount.md
@@ -22,9 +22,9 @@ brave mount [UNIT:]<source> UNIT:<target>
 brave mount $PWD/DIR UNITNAME:/PATH/TO/DIR
 ```
 
-Note that the mount requires a full path to your host directory and host directory and target directory have to have an identical name.
+Note that the mount requires a full path to your host directory. The host directory and target directory must have an identical name.
 
-Since Bravetools deploys unpriveledged containers, the fact that all uids/gids in an unprivileged container are mapped to a normally unused range on the host means that sharing of data between host and container is effectively impossible. This is circumvented internally by Bravetools by directly mapping your host uid/gid to a Bravetools Unit through `lxc config set test raw.idmap`. This enables users to read/write bound volumes inside an unpriveledged container.
+Since Bravetools deploys unprivileged containers, the fact that all uids/gids in an unprivileged container are mapped to a normally unused range on the host means that sharing of data between host and container is effectively impossible. This is circumvented internally by Bravetools by directly mapping your host uid/gid to a Bravetools Unit through `lxc config set test raw.idmap`. This enables users to read/write bound volumes inside an unprivileged container.
 
 ## Options
 

--- a/docs/docs/cli/index.md
+++ b/docs/docs/cli/index.md
@@ -12,7 +12,7 @@ nav_order: 1
 To list available commands, either run `brave` without parameters, or execute `brave help`.
 
 ```bash
-brave - tools for working with the Brave Platform
+A complete System Container management platform
 
 Usage:
   brave [command]

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -12,7 +12,7 @@ Docker is the industry-standard way for building **Application Containers**. Bra
 
 # Configuring a Bravetools Unit to run Docker
 
-A unit can be configured to run Docker containers using a [Bravefile](../bravefile). This can be achieved simply by addin `docker: "yes"` to the **service** section:
+A unit can be configured to run Docker containers using a [Bravefile](../bravefile). This can be achieved simply by adding `docker: "yes"` to the **service** section:
 
 ```yaml
 service:

--- a/docs/examples/deploy-ml-models.md
+++ b/docs/examples/deploy-ml-models.md
@@ -14,7 +14,7 @@ description: "Using Bravetools to create and ship machine learning models"
 ![gpt2-streamlit](../../assets/gpt2-streamlit.png){:class="img-responsive"}
 
 ## Motivation
-Sharing reproducible Machine Learning (ML) models and experiments is very important for our team. It allows us to better understand how ML models work as well as test model environment before deploying it in production. As models become more and more complex, managing shareable code dependencies, artifacts, system libraries, and drivers becomes rather daunting. Because of their simplicity, System Containers became our go-to tools in our day-to-day work, virtually eliminating the dreaded [dev/prod parity](https://12factor.net/dev-prod-parity).
+Sharing reproducible Machine Learning (ML) models and experiments is very important for our team. It allows us to better understand how ML models work as well as test model environment before deploying it in production. As models become more and more complex, managing shareable code dependencies, artifacts, system libraries, and drivers becomes rather daunting. Because of their simplicity, System Containers became our go-to tools in our day-to-day work, virtually eliminating the dreaded [dev/prod parity](https://12factor.net/dev-prod-parity) problem.
 
 In this example we'll use Bravetools to configure, build, and deploy a [GPT2 model](https://openai.com/blog/better-language-models/) using a simple [streamlit](https://www.streamlit.io/) application.
 
@@ -60,7 +60,7 @@ stdout_logfile_backups=10
 Supervisor will launch the streamlit script on port 8501 and, in case our environment goes down, it will attempt to autostart the app.
 
 ## Configuring application environment
-Now it's time to package all of these little bits into a self-contained System Container! We begin with a [Bravefile](../../docs/bravefile) that describes our system with all of its dependencies. For this application we'll use Ubuntu 18.04 image from the [LXD image server](https://us.images.linuxcontainers.org/) and bundle in python3 and [supervisor](http://supervisord.org/index.html).
+Now it's time to package all of these little bits into a self-contained System Container! We begin with a [Bravefile](../../docs/bravefile) that describes our system with all of its dependencies. For this application we'll use an Ubuntu 18.04 image from the [LXD image server](https://us.images.linuxcontainers.org/) and bundle in python3 and [supervisor](http://supervisord.org/index.html).
 
 ```yaml
 base:
@@ -177,7 +177,7 @@ Sharing this application is trivial. Simply publish it:
 brave publish
 ```
 
-This will produce a `tar.gz` file, which can be imported and dpeloyed elsewhere:
+This will produce a `tar.gz` file, which can be imported and deployed elsewhere:
 
 ```bash
 brave import gpt2-streamlit-20201201082229.tar.gz

--- a/docs/examples/reprodibility-bioinformatics.md
+++ b/docs/examples/reprodibility-bioinformatics.md
@@ -28,7 +28,7 @@ Our research team works extensively with Docker to build, maintain and scale a n
 
 ## Our solution
 
-We found that our issues could be largely addressed through System Containers. Our researchers could once more focus on experiments and not devops, whilst ensuring efficiency, scalability, security, and reproducibility of all pipelines. Bellow we provide an overview of our typical Bioinformatics research environment and how Bravetools can be used to build, scale, and publish all dependencies.
+We found that our issues could be largely addressed through System Containers. Our researchers could once more focus on experiments and not devops, whilst ensuring efficiency, scalability, security, and reproducibility of all pipelines. Below we provide an overview of our typical Bioinformatics research environment and how Bravetools can be used to build, scale, and publish all dependencies.
 
 > **NOTE**: System Containers are not a replacement for Docker. They are a replacement for VMs. Docker can be easily deployed inside LXD containers, a feature we take advantage of in production.
 
@@ -113,21 +113,21 @@ service:
   - 8787:8787
 ```
 
-A blank IP field will result in an ephemeral IP being generated for this unit. Since a default RStudio runs on port 8787, we will leave this unchanged.
+A blank IP field will result in an ephemeral IP being generated for this unit. Since by default RStudio runs on port 8787, we will leave this unchanged.
 
 > **NOTE** If you're using Multipass (e.g. on a Mac or Windows machine), RStudio service will be accessible from HOSTIP:8787, where HOSTIP is the IPV4 address of your Multipass host, easily obtained by running `brave info`.
 
 You can now navigate to 10.0.0.23:8787 and login using `rstudio`/`password` credentials.
 
-As a side node, installing an OpenSSH server inside this environment, will allow others to connect to it over ssh, facilitating collaborative research.
+As a side node, installing an OpenSSH server inside this environment will allow others to connect to it over ssh, facilitating collaborative research.
 
 ### Publishing the environment
 
 Now that the RStudio environment is deployed, you can work inside the unit as though you're on a remote server or inside a virtual machine. Data and packages can be added as needed.
 
-> **NOTE** If you do install additional packages, do update your Bravefile, to ensure that de novo builds are consistent with your existing environment.
+> **NOTE** If you do install additional packages, update your Bravefile to ensure that de novo builds are consistent with your existing environment.
 
-Once you're happy with your environment and are ready to migrate it to a more powerful infrastructure, share it with your team, or make it available as part of your publication, you need to simply run:
+Once you're happy with your environment and are ready to migrate it to more powerful infrastructure, share it with your team, or make it available as part of your publication, you need to simply run:
 
 ```bash
 > brave publish ubuntu-bionic-rstudio-server

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -8,7 +8,7 @@ nav_order: 3
 
 # Introduction to Bravetools
 
-Welcome to Bravetools! This introduction will show you what Bravetools is and why it exists. Checkout some of our [use cases](use_cases) to explore the benefits that Bravetools can offer. The list is not exhaustive and we're excited to see new applications in the very near future.
+Welcome to Bravetools! This introduction will show you what Bravetools is and why it exists. Check out some of our [use cases](use_cases) to explore the benefits that Bravetools can offer. The list is not exhaustive and we're excited to see new applications in the very near future.
 
 # What is Bravetools
 

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -97,7 +97,7 @@ alpine-edge-python3	Running	10.0.0.156	eth0(nic):bridged
 To delete the live image, run
 
 ```bash
-$ brave delete alpine-edge-python3
+$ brave remove alpine-edge-python3
 ```
 
 That's it! You have now configured and deployed your very first Bravetools image. Check out the [docs](../../docs) to dive deeper.

--- a/docs/intro/use_cases.md
+++ b/docs/intro/use_cases.md
@@ -9,7 +9,7 @@ In this section we highlight *some* uses cases for Bravetools, predominantly dra
 
 
 # Dev/Prod Parity
-Bravetools was conceived to keep development, staging, and production environments as similar as possible. The key advantage for us were:
+Bravetools was conceived to keep development, staging, and production environments as similar as possible. The key advantages for us were:
 
 * Making the time gap small - our developers write code and deploy it within hours or even just minutes later.
 * Making the personnel gap small - as a small company, our development team is also very small 😊. Developers who wrote code are also closely involved in deploying it and watching its behavior in production.
@@ -19,4 +19,4 @@ Bravetools was conceived to keep development, staging, and production environmen
 Many applications that are being developed internally at Bering run both on edge devices and on large cloud-based compute infrastructures. We maintain only one device-agnostic version of our code base and using bravetools, [deploy](../../docs/cli/brave_deploy) software images to appropriate hardware.
 
 # Pain-free dependency control
-Whether it's managing multi-user Data Science environments or deploying legacy code, working with system-level dependencies is painful. Since Bravetools creates consistent images from [structured configuration files](../../docs/bravefile), we can explicitly control which dependencies are bundled with our code. Each image derived form the same configuration file is guaranteed to work on all supported machines.
+Whether it's managing multi-user Data Science environments or deploying legacy code, working with system-level dependencies is painful. Since Bravetools creates consistent images from [structured configuration files](../../docs/bravefile), we can explicitly control which dependencies are bundled with our code. Each image derived from the same configuration file is guaranteed to work on all supported machines.


### PR DESCRIPTION
- Update docs for `brave init` with up-to-date info for the profile/network created by bravetools.
- `brave delete` in the docs must refer to `brave remove`
- `~/.bravetools/config.yaml` is actually called `~/.bravetools/config.yml`
- Fix typos.