### PR TITLE
Return an error when an unrecognized package manager is encountered.

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -644,6 +644,8 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 				return errors.New(shared.Fatal("failed to install packages"))
 			}
 		}
+	default:
+		return fmt.Errorf("package manager %q not recognized", pMan)
 	}
 
 	// Go through "Copy" section


### PR DESCRIPTION
Currently, if a typo is made when specifying the package manager, bravetools will silently skip the package installation phase of the build without any warning. This can lead to "successfully" publishing containers that don't actually work due to the lacking dependencies.