### PR TITLE
Raise error if empty package manager and packages to be installed

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -593,7 +593,10 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 
 	switch pMan {
 	case "":
-		fallthrough
+		// No package manager - if packages are to be installed, raise error
+		if len(bravefile.SystemPackages.System) > 0 {
+			return errors.New("package manager not specified - cannot install packages")
+		}
 	case "apk":
 		_, err := Exec(bravefile.PlatformService.Name, []string{"apk", "update", "--no-cache"}, bh.Remote)
 		if err != nil {


### PR DESCRIPTION
This builds on previous fix and covers the edge case mentioned in https://github.com/bravetools/bravetools/pull/81 where if the user forgets to specify the package manager the section is skipped even if packages are to be installed. Makes sense to return a specific error in this case. 

In addition, removing the `fallthrough` statement prevents the execution of `apk update --no-cache` from the next block in the switch statement in the event of an empty package manager, which does not seem intended.