### PR TITLE
`GetUnits` first check if eth0 key is in the map

### DIFF
--- a/platform/operations.go
+++ b/platform/operations.go
@@ -451,7 +451,9 @@ func GetUnits(remote Remote) (units []shared.BraveUnit, err error) {
 		unit.Name = n
 		unit.Status = containerState.Status
 		if strings.ToLower(containerState.Status) == "running" {
-			unit.Address = containerState.Network["eth0"].Addresses[0].Address
+			if eth, ok := containerState.Network["eth0"]; ok {
+				unit.Address = eth.Addresses[0].Address
+			}
 		}
 		unit.Disk = diskDevice
 		unit.Proxy = proxyDevice


### PR DESCRIPTION
This avoids a panic if the eth0 interface isn't present.

In most cases the interface should be there, but still best to handle the case where it is missing. It can happen when there are other LXD contaienrs not created by brave present on the system.