### PR TITLE
Enable privileged mounts on windows to allow mounting using multipass

### DIFF
--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -60,6 +62,15 @@ func (vm Multipass) BraveBackendInit() error {
 	_, err := checkMultipass()
 	if err != nil {
 		return err
+	}
+
+	if runtime.GOOS == "windows" {
+		err = shared.ExecCommand("multipass",
+			"set",
+			"local.privileged-mounts=Yes")
+		if err != nil {
+			log.Println("failed to set local.privileged-mounts to true, attempting to continue")
+		}
 	}
 
 	err = shared.ExecCommand("multipass",


### PR DESCRIPTION
Since multipass version 1.7.0 [windows mounts have been disabled by default by multipass](https://multipass.run/docs/privileged-mounts). This sets the required flag to true to enable mounts on Windows.

The command to change the flag is set to only run when Go is running on Windows OS. Older versions of multipass will not have this flag, so errors are logged but do not result in termination of build.