### PR TITLE
Username sanitization

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"regexp"
 	"syscall"
 
 	"github.com/bravetools/bravetools/shared"
@@ -16,13 +17,27 @@ import (
 
 // Private Helpers
 
-func getCurrentUsername() (string, error) {
+func getCurrentUsername() (username string, err error) {
+
 	user, err := user.Current()
 	if err != nil {
 		return "", err
 	}
 
-	username := user.Username
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		return "", err
+	}
+
+	username = reg.ReplaceAllString(user.Username, "")
+
+	// Truncate to max username length if necessary
+	usernameLength := 12
+	if len(username) < usernameLength {
+		usernameLength = len(username)
+	}
+	username = username[:usernameLength]
+
 	return username, nil
 }
 

--- a/platform/host.go
+++ b/platform/host.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/user"
 	"path"
 	"strconv"
 	"time"
@@ -95,12 +94,10 @@ func SetupHostConfiguration(params map[string]string, userHome string) {
 	poolSizeInt, _ := strconv.Atoi(params["storage"])
 	poolSizeInt = poolSizeInt - 2
 
-	user, err := user.Current()
+	hostName, err := getCurrentUsername()
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
-
-	hostName := user.Username
 
 	timestamp := time.Now()
 	storagePoolName := hostName + "-" + timestamp.Format("20060102150405")

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -318,7 +318,7 @@ func (vm Multipass) Info() (Info, error) {
 	_, err := checkMultipass()
 
 	if err != nil {
-		return backendInfo, errors.New("annot find backend service")
+		return backendInfo, errors.New("cannot find backend service")
 	}
 
 	out, err := exec.Command("multipass", "info", vm.Settings.Name).Output()

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -77,12 +76,10 @@ func SetActiveStoragePool(name string, remote Remote) error {
 		return err
 	}
 
-	user, err := user.Current()
+	username, err := getCurrentUsername()
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
-
-	username := user.Username
 
 	profile, etag, err := lxdServer.GetProfile(username)
 	if err != nil {


### PR DESCRIPTION
bravetools uses the current username for:
- Multipass VM name
- LXD profile name
- LXD storage pool name
- LXD network bridge name

However, there are various rules regarding valid names for the above. In particular, multipass VM names and LXD network bridge names are most likely to cause issues.
- LXD network bridge names are limited to 15 characters maximum
- Multipass VM names are generally restricted to most alpha-numeric characters. A hyphen is allowed, but only in some cases (for example leading/trailing hyphen is not).

This pull request attempts to sanitize usernames so that they are valid for all the above uses. It is purposefully overly-cautious by stripping any non alpha-numeric charcaters to avoid dealing with those edge cases (for now). The username is actually restricted to 12 characters maximum, since "br0" is appended to the name to create the network bridge name. 

## Problems
This approach of attempting to clean usernames has some issues - after truncating or removing characters from usernames the username may no longer be a unique identifier. However, at least this change would at least let users who otherwise would not be able to use bravetools with their current username use the program.