### PR TITLE
Address apk update pause

### DIFF
--- a/platform/operations.go
+++ b/platform/operations.go
@@ -677,13 +677,18 @@ func Exec(ctx context.Context, name string, command []string, remote Remote) (re
 		return 1, errors.New("Error getting current state: " + err.Error())
 	}
 
+	opWait := make(chan struct{})
+	go func() {
+		err = op.Wait()
+		close(opWait)
+	}()
+
 	select {
 	case <-ctx.Done():
 		return 1, ctx.Err()
-	case <-args.DataDone:
+	case <-opWait:
 	}
 
-	err = op.Wait()
 	if err != nil {
 		return 1, errors.New("Error executing command: " + err.Error())
 	}


### PR DESCRIPTION
Small bugfix to address specific `apk update` issue.

Running apk update does not close the DataDone channel unlike most other commands, leading to waiting for prompt from user before continuing. To address this use a goroutine to call op.Wait and close a channel to signal completion to select call instead.