### PR TITLE
Account for multipass backend in `lxdCheck` and `checkLXDVersion`

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -892,7 +892,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 		return err
 	}
 
-	clientVersion, _, err := checkLXDVersion(whichLxc)
+	clientVersion, _, err := vm.checkLXDVersion(whichLxc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently bravetools runs commands querying for `which lxc` and for the LXD version on the machine running bravetools within `InitUnit` using the functions `lxdCheck` and `checkLXDVersion`. Currently these functions don't account for the possibility of being called with multiple backends. This leads to errors when using a "multipass" backend - it means it isn't possible to deploy units at all on Windows.

This fix changes these functions to account for the possibility of being called from a mutlipass backend, which solves the isue and allows for deployments on multipass backends.

There may be alternative solutions - perhaps adding the path to lxc binary to the information returned by `Backend.Info`?