### PR TITLE
bravetools clean up after failed init

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -101,13 +101,13 @@ func createBraveHome(userHome string) error {
 }
 
 func deleteBraveHome(userHome string) error {
-	exists, err := shared.CheckPath(path.Join(userHome, shared.PlatformConfig))
+	exists, err := shared.CheckPath(path.Join(userHome, ".bravetools"))
 	if err != nil {
 		return err
 	}
 
 	if exists {
-		err = os.RemoveAll(path.Join(userHome, shared.PlatformConfig))
+		err = os.RemoveAll(path.Join(userHome, ".bravetools"))
 		if err != nil {
 			return err
 		}

--- a/commands/init.go
+++ b/commands/init.go
@@ -51,9 +51,9 @@ func serverInit(cmd *cobra.Command, args []string) {
 	default:
 		err := deleteBraveHome(userHome)
 		if err != nil {
-			log.Fatal(err.Error())
+			fmt.Println(err.Error())
 		}
-		log.Fatal("unsupported hos OS: ", hostOs)
+		log.Fatal("unsupported host OS: ", hostOs)
 	}
 
 	log.Println("Initialising a new Bravetools configuration")


### PR DESCRIPTION
Currently bravetools only deletes a config file when an error occurs during `brave init`. It would be preferable to completley clean up after itself by deleting the whole of ~/.bravetools rather than leaving things behind on the filesystem.

Fully removing leftover files will also allow `brave init` to work next time it is run if the root cause of the issue is solved. (As it is this needs to be done manually).

This change should be safe to make since this function is also ever called in the event of a failed initialization.