### PR TITLE
Command env variables

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -417,7 +417,7 @@ func bravefileRun(ctx context.Context, lxdServer lxd.InstanceServer, run []share
 			args = append(args, content)
 		}
 
-		status, err := Exec(ctx, lxdServer, service, args, ExecArgs{})
+		status, err := Exec(ctx, lxdServer, service, args, ExecArgs{env: c.Env})
 		if err != nil {
 			return err
 		}

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -357,7 +357,7 @@ func bravefileCopy(ctx context.Context, lxdServer lxd.InstanceServer, copy []sha
 		sourcePath := filepath.FromSlash(source)
 
 		target := c.Target
-		_, err := Exec(ctx, lxdServer, service, []string{"mkdir", "-p", target})
+		_, err := Exec(ctx, lxdServer, service, []string{"mkdir", "-p", target}, ExecArgs{})
 		if err != nil {
 			return errors.New("Failed to create target directory: " + err.Error())
 		}
@@ -385,7 +385,7 @@ func bravefileCopy(ctx context.Context, lxdServer lxd.InstanceServer, copy []sha
 		}
 
 		if c.Action != "" {
-			_, err = Exec(ctx, lxdServer, service, []string{"bash", "-c", c.Action})
+			_, err = Exec(ctx, lxdServer, service, []string{"bash", "-c", c.Action}, ExecArgs{})
 			if err != nil {
 				return errors.New("Failed to execute action: " + err.Error())
 			}
@@ -417,14 +417,13 @@ func bravefileRun(ctx context.Context, lxdServer lxd.InstanceServer, run []share
 			args = append(args, content)
 		}
 
-		status, err := Exec(ctx, lxdServer, service, args)
+		status, err := Exec(ctx, lxdServer, service, args, ExecArgs{})
 		if err != nil {
 			return err
 		}
 		if status > 0 {
 			return fmt.Errorf("non-zero exit code %d for command %q", status, strings.Join(args, " "))
 		}
-
 	}
 
 	return err

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -679,7 +679,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			return errors.New("package manager not specified - cannot install packages")
 		}
 	case "apk":
-		_, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, []string{"apk", "update", "--no-cache"})
+		_, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, []string{"apk", "update", "--no-cache"}, ExecArgs{})
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return errors.New("failed to update repositories: " + err.Error())
 		}
@@ -688,7 +688,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 		args = append(args, bravefile.SystemPackages.System...)
 
 		if len(args) > 3 {
-			status, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, args)
+			status, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, args, ExecArgs{})
 
 			if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 				return errors.New("failed to install packages: " + err.Error())
@@ -699,7 +699,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 		}
 
 	case "apt":
-		_, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, []string{"apt", "update"})
+		_, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, []string{"apt", "update"}, ExecArgs{})
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return errors.New("failed to update repositories: " + err.Error())
 		}
@@ -709,7 +709,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 
 		if len(args) > 2 {
 			args = append(args, "--yes")
-			status, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, args)
+			status, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, args, ExecArgs{})
 
 			if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 				return errors.New("failed to install packages: " + err.Error())

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -588,8 +588,11 @@ func isIPv4(ip string) bool {
 	return true
 }
 
+type ExecArgs struct {
+}
+
 // Exec runs command inside unit
-func Exec(ctx context.Context, lxdServer lxd.InstanceServer, name string, command []string) (returnCode int, err error) {
+func Exec(ctx context.Context, lxdServer lxd.InstanceServer, name string, command []string, arg ExecArgs) (returnCode int, err error) {
 	if err = ctx.Err(); err != nil {
 		return 0, err
 	}
@@ -1119,8 +1122,16 @@ func DeleteImageByName(lxdServer lxd.InstanceServer, name string) error {
 	}
 	imageFingerprint := alias.Target
 
-	_, err = lxdServer.DeleteImage(imageFingerprint)
-	return err
+	op, err := lxdServer.DeleteImage(imageFingerprint)
+	if err != nil {
+		return err
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // DeleteImageFingerprint delete unit image

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -589,6 +589,7 @@ func isIPv4(ip string) bool {
 }
 
 type ExecArgs struct {
+	env map[string]string
 }
 
 // Exec runs command inside unit
@@ -621,6 +622,7 @@ func Exec(ctx context.Context, lxdServer lxd.InstanceServer, name string, comman
 		WaitForWS:    true,
 		RecordOutput: true,
 		Interactive:  false,
+		Environment:  arg.env,
 	}
 
 	args := lxd.ContainerExecArgs{

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -18,9 +18,10 @@ type Packages struct {
 
 // RunCommand defines custom commands to run inside continer
 type RunCommand struct {
-	Command string   `yaml:"command,omitempty"`
-	Content string   `yaml:"content,omitempty"`
-	Args    []string `yaml:"args,omitempty"`
+	Command string            `yaml:"command,omitempty"`
+	Content string            `yaml:"content,omitempty"`
+	Args    []string          `yaml:"args,omitempty"`
+	Env     map[string]string `yaml:"env,omitempty"`
 }
 
 //CopyCommand defines source and target for files to be copied into container


### PR DESCRIPTION
Passing environment variables to commands in the run section of a Bravefile currently has to be done using shell commands (`sh -c 'TEST_VAR="test" ...'`). Relying on the shell is not ideal and leans into an imperative style of programming, rather than the declarative style of the rest of the Bravefile.

The LXD client provides official support for passing environment variables to `exec` commands, which works reliably and with minimal changes to the code. A small extension to the Bravefile's command to include an "env" field that exposes this would allow for an easy, declarative way to pass env variables to commands that does not involve spinning up a shell process.

Additionally, being able to avoid the `sh` command tends to make the intent of the command clearer - see the example below.

Before:
```
run:
  - command: sh
    args:
      - -c
      - 'AUTH_ADDR=10.0.0.15:80 LOG_ADDR=10.0.0.25:8000 flask run'

```
After:
```
run:
  - command: flask
    args:
      - run
    env:
      AUTH_ADDR: 10.0.0.15:80
      LOG_ADDR: 10.0.0.25:8000

```