### PR TITLE
Command detach

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -417,7 +417,7 @@ func bravefileRun(ctx context.Context, lxdServer lxd.InstanceServer, run []share
 			args = append(args, content)
 		}
 
-		status, err := Exec(ctx, lxdServer, service, args, ExecArgs{env: c.Env})
+		status, err := Exec(ctx, lxdServer, service, args, ExecArgs{env: c.Env, detach: c.Detach})
 		if err != nil {
 			return err
 		}

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -589,7 +589,8 @@ func isIPv4(ip string) bool {
 }
 
 type ExecArgs struct {
-	env map[string]string
+	env    map[string]string
+	detach bool
 }
 
 // Exec runs command inside unit
@@ -633,10 +634,18 @@ func Exec(ctx context.Context, lxdServer lxd.InstanceServer, name string, comman
 		DataDone: make(chan bool),
 	}
 
+	if arg.detach {
+		req.WaitForWS = false
+	}
+
 	op, err := lxdServer.ExecContainer(name, req, &args)
 
 	if err != nil {
 		return 1, errors.New("Error getting current state: " + err.Error())
+	}
+
+	if arg.detach {
+		return returnCode, nil
 	}
 
 	opWait := make(chan struct{})
@@ -656,9 +665,9 @@ func Exec(ctx context.Context, lxdServer lxd.InstanceServer, name string, comman
 	}
 	opAPI := op.Get()
 
-	status := int(opAPI.Metadata["return"].(float64))
+	returnCode = int(opAPI.Metadata["return"].(float64))
 
-	return status, nil
+	return returnCode, nil
 }
 
 // Delete deletes a unit on a LXD remote

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -22,6 +22,7 @@ type RunCommand struct {
 	Content string            `yaml:"content,omitempty"`
 	Args    []string          `yaml:"args,omitempty"`
 	Env     map[string]string `yaml:"env,omitempty"`
+	Detach  bool              `yaml:"detach,omitempty"`
 }
 
 //CopyCommand defines source and target for files to be copied into container


### PR DESCRIPTION
Currently, if executing a command that does not exit bravetools will wait indefinitely for the completion of the command. The usual ways of running a shell command in the background don't seem to work when using bravetools. For example, using `sh -c ... &` does not detach, nor do various uses of `nohup ... &`. If the program does not provide a flag to run as a daemon process it cannot be used from bravetools without freezing the build/deploy.

Instances of programs that don't exit may include web-servers etc. that are designed to be run in the background. This means that something like starting a web-server using a post-deploy command would not work if it has no --daemon flag, like Flask.

Adding a new field to the Bravefile run command, "detach" would enable bravetools to handle such cases and any other where running programs in the background is desired. For certain scenarios this could greatly simplify deployment and make it feel less like you are fighting bravetools to get it to do something that would have been easy with a shell script.

Here's what the new field would like like:
```
run:
  - command: flask
    args:
      - run
    detach: true
```