### PR TITLE
Apply unit default resource limitations to bravefiles on load

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -66,13 +66,6 @@ func deploy(cmd *cobra.Command, args []string) {
 
 	if len(args) > 0 {
 		bravefile.PlatformService.Image = args[0]
-		if unitCPU == "" {
-			bravefile.PlatformService.Resources.CPU = "2"
-		}
-
-		if unitRAM == "" {
-			bravefile.PlatformService.Resources.RAM = "2GB"
-		}
 	}
 
 	if name != "" {

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -77,6 +77,9 @@ func (bravefile *Bravefile) Load(file string) error {
 		return err
 	}
 
+	bravefile.PlatformService.Resources.CPU = DefaultUnitCpuLimit
+	bravefile.PlatformService.Resources.RAM = DefaultUnitRamLimit
+
 	err = yaml.Unmarshal(buf.Bytes(), &bravefile)
 	if err != nil {
 		return err

--- a/shared/constants.go
+++ b/shared/constants.go
@@ -32,3 +32,9 @@ const SnapLXC = "/snap/bin/lxc"
 
 // BraveDB path to Bravetools database
 const BraveDB = BraveHome + "/bravetools.db"
+
+// DefaultUnitCpuLimit - used if not specified
+const DefaultUnitCpuLimit = "2"
+
+// DefaultUnitRamLimit - used if not specified
+const DefaultUnitRamLimit = "2GB"


### PR DESCRIPTION
Pulling this out of https://github.com/bravetools/bravetools/pull/54 since it really is a separate change.

Currently, if attempting to deploy an image from a Bravefile that has no resources defined and without providing an image name from command line, the program will panic. In this branch, the default resources (RAM/CPU) are applied if they are left at empty values in the Bravefile, which feels more direct.

By doing this in a central place (Bravefile.Load) these defaults will apply however units are deployed (using `brave deploy` or perhaps in future `brave compose`).