### PR TITLE
Infer Image name if not provided

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -60,9 +60,6 @@ func deploy(cmd *cobra.Command, args []string) {
 		}
 
 	}
-	if (len(args) == 0) && (!useBravefile) {
-		log.Fatal("missing image name")
-	}
 
 	if len(args) > 0 {
 		bravefile.PlatformService.Image = args[0]

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -802,7 +802,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 
 	homeDir, _ := os.UserHomeDir()
 	if unitParams.PlatformService.Image == "" {
-		return errors.New("unit image name cannot be empty")
+		unitParams.PlatformService.Image = unitParams.PlatformService.Name + "-" + unitParams.PlatformService.Version
 	}
 	image := path.Join(homeDir, shared.ImageStore, unitParams.PlatformService.Image+".tar.gz")
 


### PR DESCRIPTION
Image name is invariably a concatenation of unit name and version - if user omits the field we can simply use the values for unit name and version to infer it. This is a backwards compatible change - if user supplies the value things will continue to work as usual.