### PR TITLE
Move uninstallation docs to `Install Bravetools` section

### DIFF
--- a/docs/installation/uninstall-bravetools.md
+++ b/docs/installation/uninstall-bravetools.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Uninstall Bravetools
-parent: Docs
+parent: Install Bravetools
 nav_order: 5
 description: "Instructions to uninstall Bravetools"
 ---


### PR DESCRIPTION
Uninstallation instructions are more closely related to the Installation section than to the content in the section it currently is in "Docs". The "Docs" section is more focused on usage of `bravetools` (CLI reference, Bravefiles...) than installation/uninstallation.