### PR TITLE
Wait for LXD cert to become valid

### DIFF
--- a/platform/operations.go
+++ b/platform/operations.go
@@ -146,12 +146,21 @@ func AddRemote(braveHost *BraveHost) error {
 	if err != nil {
 		return err
 	}
+	if certificate == nil {
+		return errors.New("failed to get lxd certificate - certificate is nil")
+	}
+
+	// LXD may be running in a VM and check certificate validity based on VM clock causing issues
+	// Waiting a few seconds gives a safety buffer to prevent sync issues
+	waitTime, err := time.ParseDuration("5s")
+	if err != nil {
+		return err
+	}
+	time.Sleep(waitTime)
 
 	// Handle certificate prompt
-	if certificate != nil {
-		digest := lxdshared.CertFingerprint(certificate)
-		fmt.Printf(("Certificate fingerprint: %s")+"\n", digest)
-	}
+	digest := lxdshared.CertFingerprint(certificate)
+	fmt.Printf(("Certificate fingerprint: %s")+"\n", digest)
 
 	dnam := path.Join(userHome, shared.BraveServerCertStore)
 	err = os.MkdirAll(dnam, 0750)


### PR DESCRIPTION
When running `brave init` on Windows I have been consistently encountering the following error which interrupts the init:
- 2022/07/14 16:43:57 failed to add remote host: The provided certificate isn't valid yet

It appears that [LXD recently changed their cert validation](https://github.com/lxc/lxd/blame/df84330299d1849c377a2d675874c947a490c94f/lxd/certificates.go#L1134), which seems to have tightened restrictions as this didn't happen before.

The problem likely occurs due to time-sync issues between the host and VM, since the certificate is already valid according to the host but gets rejected by LXD running inside of multipass.

Addding a short 5-second sleep after retrieving remote LXD cert appears to help prevent time sync issues between VM and host from causing the cert to be judged invalid. It's a bit arbitrary but it allows me to run `brave init` - will keep an eye on this in case we need to change the length of the sleep in future.
