### PR TITLE
Refactor `deploy`

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -46,6 +46,9 @@ func deploy(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		useBravefile = false
 		bravefile.PlatformService.Image = args[0]
+		if deployArgs.Name == "" {
+			log.Fatal("unit must have a name: pass one using the '--name' flag")
+		}
 	}
 
 	// Use Bravefile if no CLI args

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"log"
-	"os"
 
+	"github.com/bravetools/bravetools/shared"
 	"github.com/spf13/cobra"
 )
 
@@ -38,34 +38,29 @@ func includeDeployFlags(cmd *cobra.Command) {
 func deploy(cmd *cobra.Command, args []string) {
 	checkBackend()
 
-	var useBravefile = false
-	var bravefilePath string
+	var useBravefile = true
+	var bravefilePath = "Bravefile"
 	var err error
 
-	_, err = os.Stat("Bravefile")
-	// if Bravefile is in current directory continue with parameters set there
-	if err == nil {
-		useBravefile = true
-		bravefilePath = "Bravefile"
-	}
-	if unitConfig != "" {
-		useBravefile = true
-		bravefilePath = unitConfig
+	// If args provided, use CLI, not Bravefile
+	if len(args) > 0 {
+		useBravefile = false
+		bravefile.PlatformService.Image = args[0]
 	}
 
+	// Use Bravefile if no CLI args
 	if useBravefile {
+		if unitConfig != "" {
+			bravefilePath = unitConfig
+		}
+		if !shared.FileExists(bravefilePath) {
+			log.Fatalf("Bravefile not found at %q", bravefilePath)
+		}
+
 		err = bravefile.Load(bravefilePath)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-	}
-	if (len(args) == 0) && (!useBravefile) {
-		log.Fatal("missing image name")
-	}
-
-	if len(args) > 0 {
-		bravefile.PlatformService.Image = args[0]
 	}
 
 	if name != "" {

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -444,6 +444,10 @@ func addIPRules(ct string, hostPort string, ctPort string, bh *BraveHost) error 
 }
 
 func checkUnits(unitName string, bh *BraveHost) error {
+	if unitName == "" {
+		return errors.New("unit name cannot be empty")
+	}
+
 	// Unit Checks
 	unitList, err := GetUnits(bh.Remote)
 	if err != nil {

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -791,6 +791,14 @@ func (bh *BraveHost) StartUnit(name string, backend Backend) error {
 
 // InitUnit starts unit from supplied image
 func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (err error) {
+	// Check for missing mandatory fields
+	if unitParams.PlatformService.Name == "" {
+		return errors.New("unit name cannot be empty")
+	}
+	homeDir, _ := os.UserHomeDir()
+	if unitParams.PlatformService.Image == "" {
+		return errors.New("unit image name cannot be empty")
+	}
 
 	// Check if a unit with this name already exists - we don't want to delete it
 	err = checkUnits(unitParams.PlatformService.Name, bh)
@@ -800,10 +808,6 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 
 	var fingerprint string
 
-	homeDir, _ := os.UserHomeDir()
-	if unitParams.PlatformService.Image == "" {
-		return errors.New("unit image name cannot be empty")
-	}
 	image := path.Join(homeDir, shared.ImageStore, unitParams.PlatformService.Image+".tar.gz")
 	if !shared.FileExists(image) {
 		return fmt.Errorf("image %q does not exist", unitParams.PlatformService.Image)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -805,6 +805,9 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 		return errors.New("unit image name cannot be empty")
 	}
 	image := path.Join(homeDir, shared.ImageStore, unitParams.PlatformService.Image+".tar.gz")
+	if !shared.FileExists(image) {
+		return fmt.Errorf("image %q does not exist", unitParams.PlatformService.Image)
+	}
 
 	// Resource checks
 	err = CheckResources(image, backend, unitParams, bh)

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -146,12 +146,21 @@ func AddRemote(braveHost *BraveHost) error {
 	if err != nil {
 		return err
 	}
+	if certificate == nil {
+		return errors.New("failed to get lxd certificate - certificate is nil")
+	}
+
+	// LXD may be running in a VM and check certificate validity based on VM clock causing issues
+	// Waiting a few seconds gives a safety buffer to prevent sync issues
+	waitTime, err := time.ParseDuration("5s")
+	if err != nil {
+		return err
+	}
+	time.Sleep(waitTime)
 
 	// Handle certificate prompt
-	if certificate != nil {
-		digest := lxdshared.CertFingerprint(certificate)
-		fmt.Printf(("Certificate fingerprint: %s")+"\n", digest)
-	}
+	digest := lxdshared.CertFingerprint(certificate)
+	fmt.Printf(("Certificate fingerprint: %s")+"\n", digest)
 
 	dnam := path.Join(userHome, shared.BraveServerCertStore)
 	err = os.MkdirAll(dnam, 0750)

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -66,7 +66,14 @@ type Bravefile struct {
 
 // NewBravefile ..
 func NewBravefile() *Bravefile {
-	return &Bravefile{}
+	return &Bravefile{
+		PlatformService: Service{
+			Resources: Resources{
+				CPU: DefaultUnitCpuLimit,
+				RAM: DefaultUnitRamLimit,
+			},
+		},
+	}
 }
 
 // Load loads Bravefile
@@ -76,9 +83,6 @@ func (bravefile *Bravefile) Load(file string) error {
 	if err != nil {
 		return err
 	}
-
-	bravefile.PlatformService.Resources.CPU = DefaultUnitCpuLimit
-	bravefile.PlatformService.Resources.RAM = DefaultUnitRamLimit
 
 	err = yaml.Unmarshal(buf.Bytes(), &bravefile)
 	if err != nil {


### PR DESCRIPTION
This means that the default resources will be applied even if a Bravefile is not loaded from disk using the Load method. If the Bravefile is missing the resource limits the defaults will still be applied.