### PR TITLE
Win multipass dynamic ip

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -115,7 +115,11 @@ func serverInit(cmd *cobra.Command, args []string) {
 		}
 
 		settings := host.Settings
-		settings.BackendSettings.Resources.IP = info.IPv4
+		if hostOs == "windows" {
+			settings.BackendSettings.Resources.IP = info.Name + ".mshome.net"
+		} else {
+			settings.BackendSettings.Resources.IP = info.IPv4
+		}
 		err = platform.UpdateBraveSettings(settings)
 
 		if err != nil {


### PR DESCRIPTION
Multipass VM IP address is not static by default as mentioned here https://github.com/bravetools/bravetools/issues/111. Once it changes, bravetools can no longer access the VM and cannot function.

On Windows, it's possible to use `<instance_name>.mshome.net` to reach the VM no matter what IP it has, which addresses the issue.