### PR TITLE
Check for already-existing image before building image

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"path"
 
+	"github.com/bravetools/bravetools/platform"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +41,11 @@ func build(cmd *cobra.Command, args []string) {
 	}
 
 	err = host.BuildImage(bravefile)
-	if err != nil {
+	switch errType := err.(type) {
+	case nil:
+	case *platform.ImageExistsError:
+		log.Fatalf("image %q already exists - if you want to rebuild it, first delete the existing image with: `brave remove -i [IMAGE]`", errType.Name)
+	default:
 		log.Fatal(err)
 	}
 }

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -462,3 +462,9 @@ func checkUnits(unitName string, bh *BraveHost) error {
 
 	return nil
 }
+
+func imageExists(imageNameAndVersion string) bool {
+	homeDir, _ := os.UserHomeDir()
+	image := path.Join(homeDir, shared.ImageStore, imageNameAndVersion+".tar.gz")
+	return shared.FileExists(image)
+}


### PR DESCRIPTION
Currently bravetools will silently overwrite existing images. At best, this can be a waste of time and resources rebuilding an identical image. However, it is also possible that the user intended to update the image to a new version and forgot to increment the version, which would wipe the old image version without warning.

It would be safer to return an error if the image exists instead of overwriting it. The err type is checked so that we can prompt user with the steps to take if they want to replace existing image in err message (first remove image with `brave remove -i  [name]`).