### PR TITLE
Swallowed errors in bravefile run

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -655,12 +655,9 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 	}
 
 	// Go through "Run" section
-	status, err := bravefileRun(ctx, bravefile.Run, bravefile.PlatformService.Name, bh.Remote)
+	err = bravefileRun(ctx, bravefile.Run, bravefile.PlatformService.Name, bh.Remote)
 	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
-		return errors.New("failed to execute command: " + err.Error())
-	}
-	if status > 0 {
-		return errors.New(shared.Fatal("non-zero exit code: " + strconv.Itoa(status)))
+		return errors.New(shared.Fatal("failed to execute command: " + err.Error()))
 	}
 
 	// Create an image based on running container and export it. Image saved as tar.gz in project local directory.
@@ -1014,12 +1011,9 @@ func (bh *BraveHost) Postdeploy(ctx context.Context, bravefile *shared.Bravefile
 	}
 
 	if bravefile.PlatformService.Postdeploy.Run != nil {
-		status, err := bravefileRun(ctx, bravefile.PlatformService.Postdeploy.Run, bravefile.PlatformService.Name, bh.Remote)
+		err = bravefileRun(ctx, bravefile.PlatformService.Postdeploy.Run, bravefile.PlatformService.Name, bh.Remote)
 		if err != nil {
-			return err
-		}
-		if status > 0 {
-			return errors.New(shared.Fatal("non-zero exit code: " + strconv.Itoa(status)))
+			return errors.New(shared.Fatal("failed to execute command: " + err.Error()))
 		}
 	}
 


### PR DESCRIPTION
Currently errors from commands and their exit codes are only checked once at the end of `bravefileRun` function after looping through all commands. However, this means that only errors encountered on the last command will be caught - any earlier errors are overwritten by the last command. This means an error in early stages of bravefileRun will be swallowed silently.

Instead, we can check for errors on every iteration of loop runinng commands in bravefile run section and return early if we find any. This will prevent errors from earlier commands being overwritten and ignored.

To make this change, I needed to interpret non-zero exit codes as errors in `bravefileRun` function itself to terminate the loop. This was done anyway in host_api.go so should cause any new issues.