### PR TITLE
Resolve base image location

### DIFF
--- a/commands/base.go
+++ b/commands/base.go
@@ -26,7 +26,7 @@ func buildBase(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if strings.Contains(args[0], "github.com") {
+	if strings.HasPrefix(args[0], "github.com/") {
 		bravefile, err = shared.GetBravefileFromGitHub(args[0])
 		if err != nil {
 			log.Fatal(err)

--- a/docs/docs/bravefile.md
+++ b/docs/docs/bravefile.md
@@ -31,6 +31,8 @@ Three types of image locations are supported:
 
 In cases where Bravefiles are ingested from GitHub, a local copy of the resulting image will be kept. The local image copy will be re-used next time you run ``brave build``.
 
+If the location field is not present, bravetools will resolve the image location itself. Local images will be checked first, then public LXD images. Image names starting with "github.com/" will be imported from GitHub.
+
 ### system
 Describes system packages to be installed through a specified package manager. Supported package managers are ``apt`` and ``apk``.
 

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -665,7 +665,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 		}
 	case "local":
 		// Check disk space
-		imgSize, err := localImageSize(bravefile.PlatformService.Image)
+		imgSize, err := localImageSize(bravefile.Base.Image)
 		if err != nil {
 			return err
 		}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -619,6 +619,14 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 		DeleteImageByFingerprint(lxdServer, imageFingerprint)
 	}()
 
+	// If base image location not provided, attempt to infer it
+	if bravefile.Base.Location == "" {
+		bravefile.Base.Location, err = resolveBaseImageLocation(bravefile.Base.Image)
+		if err != nil {
+			return fmt.Errorf("base image %q does not exist: %s", bravefile.Base.Image, err.Error())
+		}
+	}
+
 	switch bravefile.Base.Location {
 	case "public":
 		// Check disk space

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -507,12 +507,7 @@ func Launch(ctx context.Context, localLxd lxd.InstanceServer, name string, alias
 	if err != nil {
 		return fingerprint, err
 	}
-	remoteImage, _, err := remoteLxd.GetImageAlias(alias)
-	if err != nil {
-		return fingerprint, err
-	}
-
-	fingerprint = remoteImage.Target
+	fingerprint, err = GetFingerprintByAlias(remoteLxd, alias)
 
 	if err = ctx.Err(); err != nil {
 		return "", err
@@ -1099,13 +1094,23 @@ func ExportImage(lxdServer lxd.ImageServer, fingerprint string, name string) err
 	return nil
 }
 
+// GetFingerprintByAlias retrieves image fingerprint corresponding to provided alias
+func GetFingerprintByAlias(lxdServer lxd.ImageServer, alias string) (fingerprint string, err error) {
+	remoteAlias, _, err := lxdServer.GetImageAlias(alias)
+	if err != nil {
+		return "", err
+	}
+	fingerprint = remoteAlias.Target
+
+	return fingerprint, nil
+}
+
 // GetImageByAlias retrieves image by name
 func GetImageByAlias(lxdImageServer lxd.ImageServer, alias string) (image *api.Image, err error) {
-	remoteAlias, _, err := lxdImageServer.GetImageAlias(alias)
+	imageFingerprint, err := GetFingerprintByAlias(lxdImageServer, alias)
 	if err != nil {
 		return nil, err
 	}
-	imageFingerprint := remoteAlias.Target
 
 	image, _, err = lxdImageServer.GetImage(imageFingerprint)
 	return image, err

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -89,6 +89,9 @@ func GetBravefileFromGitHub(name string) (*Bravefile, error) {
 	var baseConfig string
 
 	path := strings.SplitN(name, "/", -1)
+	if len(path) <= 3 {
+		return nil, fmt.Errorf("failed to retrieve image %q from github", name)
+	}
 	user := path[1]
 	repository := path[2]
 	project := strings.Join(path[3:], "/")


### PR DESCRIPTION
At the moment it is mandatory to specify the base image location in the bravefile. Ideally this would not be necessary - it should not matter where the image is stored. The user should simply declare which image they want and the tool should automatically retrieve it in the smartest way possible.

This PR allows bravetools to infer image location by itself if not provided. First it will check the local image store for the image, before searching the public LXD image repo. GitHub images are identified by the presence of the "github.com/" prefix, just like when using the `brave base` command.

The "location" field still exists as an optional field - when specified it takes precedence over the above image location resolution logic, so this change is backwards compatible with existing Bravefiles. This allows the user to override the retrieval logic if necessary, but otherwise they can avoid twiddling with the Bravefile fields to account for whether image has been stored locally.