### PR TITLE
Resource checks

### DIFF
--- a/commands/base.go
+++ b/commands/base.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"log"
 	"strings"
 
@@ -38,26 +37,6 @@ func buildBase(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-	}
-
-	// Resource checks
-	info, err := backend.Info()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	usedDiskSize, err := shared.SizeCountToInt(info.Disk[0])
-	if err != nil {
-		log.Fatal(err)
-	}
-	totalDiskSize, err := shared.SizeCountToInt(info.Disk[1])
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if (totalDiskSize - usedDiskSize) < 5000000000 {
-		err = errors.New("not enough free storage on disk")
-		log.Fatal(err)
 	}
 
 	err = host.BuildImage(bravefile)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -106,6 +106,7 @@ func loadConfig() {
 	var err error
 	host = *platform.NewBraveHost()
 	backend, err = platform.NewHostBackend(host)
+	host.Backend = backend
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/platform/backend.go
+++ b/platform/backend.go
@@ -18,9 +18,14 @@ type Info struct {
 	Release       string
 	ImageHash     string
 	Load          string
-	Disk          []string
-	Memory        []string
+	Disk          StorageUsage
+	Memory        StorageUsage
 	CPU           string
+}
+
+type StorageUsage struct {
+	UsedStorage  string
+	TotalStorage string
 }
 
 // NewHostBackend returns a new Backend from provided host Settings

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -256,8 +256,8 @@ func (bh *BraveHost) HostInfo(backend Backend, short bool) error {
 	table.SetHeader([]string{"Name", "State", "IPv4", "Disk", "Memory", "CPU"})
 
 	r := []string{info.Name, info.State, info.IPv4,
-		info.Disk[0] + " of " + info.Disk[1],
-		info.Memory[0] + " of " + info.Memory[1], info.CPU}
+		info.Disk.UsedStorage + " of " + info.Disk.TotalStorage,
+		info.Memory.UsedStorage + " of " + info.Memory.TotalStorage, info.CPU}
 
 	table.Append(r)
 	table.SetAutoWrapText(false)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -568,6 +568,16 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 
 	switch bravefile.Base.Location {
 	case "public":
+		// Check disk space
+		img, err := PublicLXDImageByAlias(bravefile.Base.Image)
+		if err != nil {
+			return err
+		}
+		err = CheckBackendDiskSpace(bh.Backend, img.Size)
+		if err != nil {
+			return err
+		}
+
 		imageFingerprint, err = importLXD(ctx, bravefile, bh.Remote)
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return err

--- a/platform/lxd.go
+++ b/platform/lxd.go
@@ -304,8 +304,8 @@ func (vm Lxd) Info() (Info, error) {
 	backendInfo.Release = ""
 	backendInfo.ImageHash = ""
 	backendInfo.Load = ""
-	backendInfo.Disk = []string{}
-	backendInfo.Memory = []string{}
+	backendInfo.Disk = StorageUsage{}
+	backendInfo.Memory = StorageUsage{}
 
 	storageInfo, err := shared.ExecCommandWReturn(whichLxc,
 		"storage",
@@ -351,7 +351,7 @@ func (vm Lxd) Info() (Info, error) {
 	usedDisk = shared.FormatByteCountSI(usedDiskInt)
 	totalDisk = shared.FormatByteCountSI(totalDiskInt)
 
-	backendInfo.Disk = []string{usedDisk, totalDisk}
+	backendInfo.Disk = StorageUsage{usedDisk, totalDisk}
 
 	totalMemCmd := "cat /proc/meminfo | grep MemTotal | awk '{print $2}'"
 	availableMemCmd := "cat /proc/meminfo | grep MemAvailable | awk '{print $2}'"
@@ -380,7 +380,7 @@ func (vm Lxd) Info() (Info, error) {
 	totalMem = shared.FormatByteCountSI(totalMemInt * 1000)
 	usedMem := shared.FormatByteCountSI(usedMemInt * 1000)
 
-	backendInfo.Memory = []string{usedMem, totalMem}
+	backendInfo.Memory = StorageUsage{usedMem, totalMem}
 
 	cpuCmd := "grep -c ^processor /proc/cpuinfo"
 	cpu, err := shared.ExecCommandWReturn("sh",

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -404,7 +404,7 @@ func (vm Multipass) Info() (Info, error) {
 		usedDisk = shared.FormatByteCountSI(usedDiskInt)
 		totalDisk = shared.FormatByteCountSI(totalDiskInt)
 
-		backendInfo.Disk = []string{usedDisk, totalDisk}
+		backendInfo.Disk = StorageUsage{usedDisk, totalDisk}
 
 		totalMemCmd := "cat /proc/meminfo | grep MemTotal | awk '{print $2}'"
 		availableMemCmd := "cat /proc/meminfo | grep MemAvailable | awk '{print $2}'"
@@ -447,7 +447,7 @@ func (vm Multipass) Info() (Info, error) {
 		totalMem = shared.FormatByteCountSI(int64(totalMemInt * 1000))
 		usedMem := shared.FormatByteCountSI(int64(usedMemInt * 1000))
 
-		backendInfo.Memory = []string{usedMem, totalMem}
+		backendInfo.Memory = StorageUsage{usedMem, totalMem}
 
 		cpuCount := "grep -c ^processor /proc/cpuinfo"
 		cpu, err := shared.ExecCommandWReturn("multipass",
@@ -464,8 +464,8 @@ func (vm Multipass) Info() (Info, error) {
 
 		backendInfo.CPU = cpu
 	} else {
-		backendInfo.Memory = []string{"Unknown", "Unknown"}
-		backendInfo.Disk = []string{"Unknown", "Unknown"}
+		backendInfo.Memory = StorageUsage{"Unknown", "Unknown"}
+		backendInfo.Disk = StorageUsage{"Unknown", "Unknown"}
 		backendInfo.CPU = "Unknown"
 	}
 

--- a/platform/resources.go
+++ b/platform/resources.go
@@ -23,11 +23,11 @@ func CheckResources(image string, backend Backend, unitParams *shared.Bravefile,
 		return errors.New("Failed to connect to host: " + err.Error())
 	}
 
-	usedDiskSize, err := shared.SizeCountToInt(info.Disk[0])
+	usedDiskSize, err := shared.SizeCountToInt(info.Disk.UsedStorage)
 	if err != nil {
 		return err
 	}
-	totalDiskSize, err := shared.SizeCountToInt(info.Disk[1])
+	totalDiskSize, err := shared.SizeCountToInt(info.Disk.TotalStorage)
 	if err != nil {
 		return err
 	}
@@ -36,11 +36,11 @@ func CheckResources(image string, backend Backend, unitParams *shared.Bravefile,
 		return errors.New("requested unit size exceeds available disk space on bravetools host. To increase storage pool size modify $HOME/.bravetools/config.yml and run brave configure")
 	}
 
-	usedMemorySize, err := shared.SizeCountToInt(info.Memory[0])
+	usedMemorySize, err := shared.SizeCountToInt(info.Memory.UsedStorage)
 	if err != nil {
 		return err
 	}
-	totalMemorySize, err := shared.SizeCountToInt(info.Memory[1])
+	totalMemorySize, err := shared.SizeCountToInt(info.Memory.TotalStorage)
 	if err != nil {
 		return err
 	}

--- a/platform/resources.go
+++ b/platform/resources.go
@@ -15,41 +15,31 @@ func CheckResources(image string, backend Backend, unitParams *shared.Bravefile,
 	if err != nil {
 		return err
 	}
-
-	requestedImageSize := fi.Size()
-
 	info, err := backend.Info()
 	if err != nil {
 		return errors.New("Failed to connect to host: " + err.Error())
 	}
 
-	usedDiskSize, err := shared.SizeCountToInt(info.Disk.UsedStorage)
-	if err != nil {
-		return err
-	}
-	totalDiskSize, err := shared.SizeCountToInt(info.Disk.TotalStorage)
+	requestedImageSize := fi.Size()
+	freeDiskSpace, err := getFreeSpace(info.Disk)
 	if err != nil {
 		return err
 	}
 
-	if requestedImageSize*5 > (totalDiskSize - usedDiskSize) {
+	if requestedImageSize*5 > freeDiskSpace {
 		return errors.New("requested unit size exceeds available disk space on bravetools host. To increase storage pool size modify $HOME/.bravetools/config.yml and run brave configure")
 	}
 
-	usedMemorySize, err := shared.SizeCountToInt(info.Memory.UsedStorage)
-	if err != nil {
-		return err
-	}
-	totalMemorySize, err := shared.SizeCountToInt(info.Memory.TotalStorage)
-	if err != nil {
-		return err
-	}
 	requestedMemorySize, err := shared.SizeCountToInt(unitParams.PlatformService.Resources.RAM)
 	if err != nil {
 		return err
 	}
+	freeMemorySize, err := getFreeSpace(info.Memory)
+	if err != nil {
+		return err
+	}
 
-	if requestedMemorySize > (totalMemorySize - usedMemorySize) {
+	if requestedMemorySize > freeMemorySize {
 		return errors.New("Requested unit memory (" + unitParams.PlatformService.Resources.RAM + ") exceeds available memory on bravetools host")
 	}
 
@@ -70,6 +60,38 @@ func CheckResources(image string, backend Backend, unitParams *shared.Bravefile,
 	err = shared.TCPPortStatus(hostIP, hostPorts)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func getFreeSpace(storageUsage StorageUsage) (freeSpace int64, err error) {
+	usedStorageBytes, err := shared.SizeCountToInt(storageUsage.UsedStorage)
+	if err != nil {
+		return freeSpace, errors.New("failed to retrieve backend disk usage:" + err.Error())
+	}
+	totalStorageBytes, err := shared.SizeCountToInt(storageUsage.TotalStorage)
+	if err != nil {
+		return freeSpace, errors.New("failed to retrieve backend disk space:" + err.Error())
+	}
+
+	return totalStorageBytes - usedStorageBytes, nil
+}
+
+// CheckBackendDiskSpace checks whether backend has enough disk space for requested allocation
+func CheckBackendDiskSpace(backend Backend, requestedSpace int64) (err error) {
+	info, err := backend.Info()
+	if err != nil {
+		return errors.New("Failed to connect to host: " + err.Error())
+	}
+
+	freeSpace, err := getFreeSpace(info.Disk)
+	if err != nil {
+		return err
+	}
+
+	if requestedSpace >= freeSpace {
+		return errors.New("requested unit size exceeds available disk space on bravetools host. To increase storage pool size modify $HOME/.bravetools/config.yml and run brave configure")
 	}
 
 	return nil

--- a/platform/resources.go
+++ b/platform/resources.go
@@ -20,7 +20,7 @@ func CheckResources(image string, backend Backend, unitParams *shared.Bravefile,
 
 	info, err := backend.Info()
 	if err != nil {
-		return err
+		return errors.New("Failed to connect to host: " + err.Error())
 	}
 
 	usedDiskSize, err := shared.SizeCountToInt(info.Disk[0])
@@ -54,12 +54,7 @@ func CheckResources(image string, backend Backend, unitParams *shared.Bravefile,
 	}
 
 	// Networking Checks
-	hostInfo, err := backend.Info()
-	if err != nil {
-		return errors.New("Failed to connect to host: " + err.Error())
-	}
-
-	hostIP := hostInfo.IPv4
+	hostIP := info.IPv4
 	ports := unitParams.PlatformService.Ports
 	var hostPorts []string
 	if len(ports) > 0 {

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -274,7 +274,7 @@ func FormatByteCountSI(b int64) string {
 		float64(b)/float64(div), "kMGTPE"[exp])
 }
 
-// SizeCountToInt convert size strings to integers
+// SizeCountToInt convert size strings to integer bytes
 func SizeCountToInt(s string) (int64, error) {
 	unitMap := map[string]int64{
 		"B":  1,


### PR DESCRIPTION
This is a step on the way to more consistent resource checking.

Changes:
- Removed overly restrictive `brave base` space checking logic (5GB space minimum)
- Added check to `BuildImage` for "public" images that ensures enough space is available before importing the image. Used during `base` and `build` commands.
- Added a struct StorageUsage and utility function that takes the struct returns free space in bytes 
- Added  the Backend field of the BraveHost during initialization to allow `BuildImage` to check the available space