### PR TITLE
Fix the DeleteImageByName function

### DIFF
--- a/platform/operations.go
+++ b/platform/operations.go
@@ -1204,13 +1204,14 @@ func DeleteImageByName(name string, remote Remote) error {
 		return err
 	}
 
-	err = lxdServer.DeleteImageAlias(name)
+	alias, _, err := lxdServer.GetImageAlias(name)
 	if err != nil {
 		return err
 	}
+	imageFingerprint := alias.Target
 
-	fmt.Println(name)
-	return nil
+	_, err = lxdServer.DeleteImage(imageFingerprint)
+	return err
 }
 
 // DeleteImageFingerprint delete unit image


### PR DESCRIPTION
This function is currently not used, but that's probably because it doesn't behave as expected. It deletes the image alias entry leaving the untagged image behind. With this change, it now deletes the image with that name rather than the alias entry itself