### PR TITLE
Fix race condition in image cleanup when import local image

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -175,10 +175,14 @@ func importLocal(ctx context.Context, bravefile *shared.Bravefile, remote Remote
 		return "", err
 	}
 	home, _ := os.UserHomeDir()
-	location := filepath.Join(home, shared.ImageStore)
+	path := filepath.Join(home, shared.ImageStore, bravefile.Base.Image) + ".tar.gz"
 
-	fingerprint, err = ImportImage(filepath.Join(location, bravefile.Base.Image)+".tar.gz", bravefile.Base.Image, remote)
+	fingerprint, err = shared.FileSha256Hash(path)
+	if err != nil {
+		return fingerprint, err
+	}
 
+	_, err = ImportImage(path, bravefile.Base.Image, remote)
 	if err != nil {
 		return fingerprint, errors.New("failed to import image: " + err.Error())
 	}

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"bytes"
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -337,6 +338,23 @@ func FileHash(filePath string) (string, error) {
 	s.Stop()
 
 	return MD5String, nil
+}
+
+func FileSha256Hash(path string) (fingerprint string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return fingerprint, err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	_, err = io.Copy(hasher, f)
+	if err != nil {
+		return fingerprint, err
+	}
+
+	fingerprint = hex.EncodeToString(hasher.Sum(nil))
+	return fingerprint, nil
 }
 
 //CheckPath checks if path exists


### PR DESCRIPTION
When running `brave deploy` or `brave build` against a local image, the image fingerprint would not be returned until after the image was fully imported (we had to wait for operation to complete). As a result, interruption to build/deploy at this stage would mean cleanup code failed to work as it didn't have the image fingerprint to delete.

Instead we can get the sha256 hash from the local file on disk instead to get the image fingerprint before starting the import for local images. This allows for cleanup without race conditions.