### PR TITLE
Set BraveHost Backend in factory function

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -104,9 +104,12 @@ func deleteBraveHome(userHome string) error {
 
 func loadConfig() {
 	var err error
-	host = *platform.NewBraveHost()
-	backend, err = platform.NewHostBackend(host)
-	host.Backend = backend
+	h, err := platform.NewBraveHost()
+	if err != nil {
+		log.Fatal(err)
+	}
+	host = *h
+	backend = host.Backend
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/info.go
+++ b/commands/info.go
@@ -25,7 +25,7 @@ func includeInfoFlags(cmd *cobra.Command) {
 
 func hostInfoList(cmd *cobra.Command, args []string) {
 	checkBackend()
-	err := host.HostInfo(backend, short)
+	err := host.HostInfo(short)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/platform/backend.go
+++ b/platform/backend.go
@@ -29,14 +29,14 @@ type StorageUsage struct {
 }
 
 // NewHostBackend returns a new Backend from provided host Settings
-func NewHostBackend(host BraveHost) (backend Backend, err error) {
-	backendType := host.Settings.BackendSettings.Type
+func NewHostBackend(hostSetings HostSettings) (backend Backend, err error) {
+	backendType := hostSetings.BackendSettings.Type
 
 	switch backendType {
 	case "multipass":
-		backend = NewMultipass(host.Settings)
+		backend = NewMultipass(hostSetings)
 	case "lxd":
-		backend = NewLxd(host.Settings)
+		backend = NewLxd(hostSetings)
 	default:
 		err = fmt.Errorf("backend type %q not supported", backendType)
 	}

--- a/platform/host.go
+++ b/platform/host.go
@@ -69,23 +69,30 @@ type BraveHost struct {
 }
 
 // NewBraveHost returns Brave host
-func NewBraveHost() *BraveHost {
-	userHome, _ := os.UserHomeDir()
-
-	settings, err := loadHostSettings(userHome)
+func NewBraveHost() (*BraveHost, error) {
+	userHome, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
-	remote, err := loadRemoteSettings(userHome, settings.BackendSettings.Resources.IP)
+	host := BraveHost{}
+
+	host.Settings, err = loadHostSettings(userHome)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
-	return &BraveHost{
-		Settings: settings,
-		Remote:   remote,
+	host.Remote, err = loadRemoteSettings(userHome, host.Settings.BackendSettings.Resources.IP)
+	if err != nil {
+		return nil, err
 	}
+
+	host.Backend, err = NewHostBackend(host.Settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return &host, nil
 }
 
 type HostConfig struct {

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -237,8 +237,8 @@ func (bh *BraveHost) DeleteLocalImage(name string) error {
 }
 
 // HostInfo returns useful information about brave host
-func (bh *BraveHost) HostInfo(backend Backend, short bool) error {
-	info, err := backend.Info()
+func (bh *BraveHost) HostInfo(short bool) error {
+	info, err := bh.Backend.Info()
 	if err != nil {
 		return errors.New("failed to connect to host: " + err.Error())
 	}

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func Test_DeleteLocalImage(t *testing.T) {
-	host := *NewBraveHost()
+	host, err := NewBraveHost()
+	if err != nil {
+		t.Fatal("failed to create host: ", err.Error())
+	}
 
 	bravefile, err := shared.GetBravefileFromLXD("alpine/edge/amd64")
 	if err != nil {
@@ -28,20 +31,22 @@ func Test_DeleteLocalImage(t *testing.T) {
 }
 
 func Test_HostInfo(t *testing.T) {
-	host := *NewBraveHost()
-	backend, err := NewHostBackend(host)
+	host, err := NewBraveHost()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("failed to create host: ", err.Error())
 	}
 
-	err = host.HostInfo(backend, false)
+	err = host.HostInfo(false)
 	if err != nil {
 		t.Error("host.HostInfo: ", err)
 	}
 }
 
 func Test_BuildImage(t *testing.T) {
-	host := *NewBraveHost()
+	host, err := NewBraveHost()
+	if err != nil {
+		t.Fatal("failed to create host: ", err.Error())
+	}
 
 	bravefile := *shared.NewBravefile()
 	bravefile.Base.Image = "alpine/edge/amd64"
@@ -59,7 +64,7 @@ func Test_BuildImage(t *testing.T) {
 	bravefile.PlatformService.Name = "alpine-test"
 	bravefile.PlatformService.Version = "1.0"
 
-	err := host.BuildImage(&bravefile)
+	err = host.BuildImage(&bravefile)
 	if err != nil {
 		t.Error("host.BuildImage: ", err)
 	}
@@ -71,10 +76,9 @@ func Test_BuildImage(t *testing.T) {
 }
 
 func Test_InitUnit(t *testing.T) {
-	host := *NewBraveHost()
-	backend, err := NewHostBackend(host)
+	host, err := NewBraveHost()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("failed to create host: ", err.Error())
 	}
 
 	ctx := context.Background()
@@ -111,7 +115,7 @@ func Test_InitUnit(t *testing.T) {
 		t.Error("host.BuildImage: ", err)
 	}
 
-	err = host.InitUnit(backend, &bravefile)
+	err = host.InitUnit(host.Backend, &bravefile)
 	if err != nil {
 		t.Error("host.InitUnit: ", err)
 	}
@@ -126,12 +130,12 @@ func Test_InitUnit(t *testing.T) {
 		t.Error("host.DeleteImageByName: ", err)
 	}
 
-	err = host.StopUnit("alpine-test", backend)
+	err = host.StopUnit("alpine-test", host.Backend)
 	if err != nil {
 		t.Error("host.StopUnit: ", err)
 	}
 
-	err = host.StartUnit("alpine-test", backend)
+	err = host.StartUnit("alpine-test", host.Backend)
 	if err != nil {
 		t.Error("host.StartUnit: ", err)
 	}
@@ -143,13 +147,12 @@ func Test_InitUnit(t *testing.T) {
 }
 
 func Test_ListLocalImages(t *testing.T) {
-	host := *NewBraveHost()
-	backend, err := NewHostBackend(host)
+	host, err := NewBraveHost()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("failed to create host: ", err.Error())
 	}
 
-	err = host.HostInfo(backend, false)
+	err = host.HostInfo(false)
 	if err != nil {
 		t.Error("host.HostInfo: ", err)
 	}
@@ -161,18 +164,17 @@ func Test_ListLocalImages(t *testing.T) {
 }
 
 func Test_ListUnits(t *testing.T) {
-	host := *NewBraveHost()
-	backend, err := NewHostBackend(host)
+	host, err := NewBraveHost()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("failed to create host: ", err.Error())
 	}
 
-	err = host.HostInfo(backend, false)
+	err = host.HostInfo(false)
 	if err != nil {
 		t.Error("host.HostInfo: ", err)
 	}
 
-	err = host.ListUnits(backend)
+	err = host.ListUnits(host.Backend)
 	if err != nil {
 		t.Error("host.ListLocalImages: ", err)
 	}


### PR DESCRIPTION
A host must always have a Backend due to use for resource checks so this makes sense to enforce in factory function to avoid creation of invalid BraveHosts. Conceptually this aligns with current Bravetools design - there's always a local Backend on the host used for building and deploying.

Update tests and commands to use new function. 

BraveHost.HostInfo method now returns info about the bravehost backend - its name implies and fact that it is attached to BraveHost suggests that it should only return information about current host.