### PR TITLE
Concurrent multipass info

### DIFF
--- a/platform/backend.go
+++ b/platform/backend.go
@@ -23,6 +23,14 @@ type Info struct {
 	CPU           string
 }
 
+func NewInfo() Info {
+	return Info{
+		Disk:   StorageUsage{"Unknown", "Unknown"},
+		Memory: StorageUsage{"Unknown", "Unknown"},
+		CPU:    "Unknown",
+	}
+}
+
 type StorageUsage struct {
 	UsedStorage  string
 	TotalStorage string

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -324,6 +324,7 @@ func (vm Multipass) Info() (backendInfo Info, err error) {
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 	s.Suffix = " " + operation
 	s.Start()
+	defer s.Stop()
 
 	_, err = checkMultipass()
 
@@ -350,7 +351,6 @@ func (vm Multipass) Info() (backendInfo Info, err error) {
 			return backendInfo, errors.New("cannot assess CPU count: " + err.Error())
 		}
 	}
-	s.Stop()
 
 	return backendInfo, nil
 }

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -349,18 +349,15 @@ func (vm Multipass) Info() (backendInfo Info, err error) {
 		if err != nil {
 			return backendInfo, errors.New("cannot assess CPU count: " + err.Error())
 		}
-	} else {
-		backendInfo.Memory = StorageUsage{"Unknown", "Unknown"}
-		backendInfo.Disk = StorageUsage{"Unknown", "Unknown"}
-		backendInfo.CPU = "Unknown"
 	}
-
 	s.Stop()
 
 	return backendInfo, nil
 }
 
-func (vm Multipass) getInfo() (backendInfo Info, err error) {
+func (vm Multipass) getInfo() (Info, error) {
+
+	backendInfo := NewInfo()
 
 	out, err := exec.Command("multipass", "info", vm.Settings.Name).Output()
 	if err != nil {


### PR DESCRIPTION
`backend.Info` is called in the course of most bravetools commands but takes an unexpectedly long time to complete on Multipass on Windows - generally several seconds (I've seen up to 9 seconds, but more commonly 8-8.5). This makes normal usage of the tool feel slow and less snappy - for example when stopping/starting multiple units there's often a delay after each command.

This change makes the calls within multipass Info concurrent, speeding up the function by a few seconds (I've saved about 2 seconds on average, from 8.6 -> 6.4 seconds). This makes a surprisingly big difference when running many small bravetools commands sequentially.