### PR TITLE
Lxd version from client

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -433,7 +433,7 @@ func cleanUnusedStoragePool(name string, remote Remote) {
 }
 
 // addIPRules adds firewall rule to the host iptable
-func addIPRules(ct string, hostPort string, ctPort string, bh *BraveHost) error {
+func addIPRules(ct string, hostPort string, ctPort string, remote Remote) error {
 
 	name := ct + "-proxy-" + hostPort + "-" + ctPort
 
@@ -443,7 +443,7 @@ func addIPRules(ct string, hostPort string, ctPort string, bh *BraveHost) error 
 	config["listen"] = "tcp:0.0.0.0:" + hostPort
 	config["connect"] = "tcp:127.0.0.1:" + ctPort
 
-	err := AddDevice(ct, name, config, bh.Remote)
+	err := AddDevice(ct, name, config, remote)
 	if err != nil {
 		return errors.New("failed to add proxy settings for unit " + err.Error())
 	}
@@ -451,13 +451,13 @@ func addIPRules(ct string, hostPort string, ctPort string, bh *BraveHost) error 
 	return nil
 }
 
-func checkUnits(unitName string, bh *BraveHost) error {
+func checkUnits(unitName string, remote Remote) error {
 	if unitName == "" {
 		return errors.New("unit name cannot be empty")
 	}
 
 	// Unit Checks
-	unitList, err := GetUnits(bh.Remote)
+	unitList, err := GetUnits(remote)
 	if err != nil {
 		return err
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -927,20 +927,14 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 		gid = user.Gid
 	}
 
-	vm := *NewLxd(bh.Settings)
-	_, whichLxc, err := lxdCheck(vm)
+	serverVersion, err := GetLXDServerVersion(bh.Remote)
 	if err != nil {
-		return err
-	}
-
-	clientVersion, _, err := vm.checkLXDVersion(whichLxc)
-	if err != nil {
-		return err
+		return errors.New("failed to get server version: " + err.Error())
 	}
 
 	// uid and gid mapping is not allowed in non-snap LXD. Shares can be created, but they are read-only in a unit.
 	var config map[string]string
-	if clientVersion <= 303 {
+	if serverVersion <= 303 {
 		config = map[string]string{
 			"limits.cpu":       unitParams.PlatformService.Resources.CPU,
 			"limits.memory":    unitParams.PlatformService.Resources.RAM,

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -548,7 +548,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 		return errors.New("service Name is empty")
 	}
 
-	err := checkUnits(bravefile.PlatformService.Name, bh)
+	err := checkUnits(bravefile.PlatformService.Name, bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -829,7 +829,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 	}
 
 	// Check if a unit with this name already exists - we don't want to delete it
-	err = checkUnits(unitParams.PlatformService.Name, bh)
+	err = checkUnits(unitParams.PlatformService.Name, bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -994,7 +994,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 				return
 			}
 
-			err = addIPRules(unitParams.PlatformService.Name, ps[1], ps[0], bh)
+			err = addIPRules(unitParams.PlatformService.Name, ps[1], ps[0], bh.Remote)
 			if err = shared.CollectErrors(err, ctx.Err()); err != nil {
 				return errors.New("unable to add Proxy Device: " + err.Error())
 			}

--- a/platform/lxd.go
+++ b/platform/lxd.go
@@ -123,7 +123,7 @@ func (vm Lxd) BraveBackendInit() error {
 
 func initiateLxd(vm Lxd, whichLxc string) error {
 
-	_, _, err := vm.checkLXDVersion(whichLxc)
+	_, _, err := checkLXDVersion(whichLxc)
 	if err != nil {
 		return err
 	}
@@ -200,23 +200,11 @@ func initiateLxd(vm Lxd, whichLxc string) error {
 	return nil
 }
 
-func (vm Lxd) checkLXDVersion(whichLxc string) (clientVersion int, serverVersion int, err error) {
-	var ver string
+func checkLXDVersion(whichLxc string) (clientVersion int, serverVersion int, err error) {
 
-	switch vm.Settings.BackendSettings.Type {
-	case "lxd":
-		ver, err = shared.ExecCommandWReturn(
-			whichLxc,
-			"version")
-	case "multipass":
-		ver, err = shared.ExecCommandWReturn(
-			"multipass",
-			"exec",
-			vm.Settings.Name,
-			"--",
-			whichLxc,
-			"version")
-	}
+	ver, err := shared.ExecCommandWReturn(
+		whichLxc,
+		"version")
 
 	if err != nil {
 		return clientVersion, serverVersion, errors.New("cannot get LXD version")
@@ -247,7 +235,7 @@ func (vm Lxd) checkLXDVersion(whichLxc string) (clientVersion int, serverVersion
 		fmt.Println("Server version: ", serverVersion)
 		return serverVersion, serverVersion, errors.New("Bravetools supports LXD >= 3.0.3. Found " + clientVersionString)
 	}
-	return serverVersion, serverVersion, nil
+	return clientVersion, serverVersion, nil
 }
 
 func enableRemote(vm Lxd, whichLxc string) error {

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -1518,3 +1518,23 @@ func imageByAlias(lxdImageServer lxd.ImageServer, alias string) (image *api.Imag
 	image, _, err = lxdImageServer.GetImage(imageFingerprint)
 	return image, err
 }
+
+// GetLXDServerVersion retrieves server semantic version and converts to integer
+func GetLXDServerVersion(remote Remote) (int, error) {
+	server, err := GetLXDServer(remote.key, remote.cert, remote.remoteURL)
+	if err != nil {
+		return -1, err
+	}
+
+	serverStatus, _, err := server.GetServer()
+	if err != nil {
+		return -1, err
+	}
+
+	serverVersionString := strings.ReplaceAll(serverStatus.Environment.ServerVersion, ".", "")
+	if len(serverVersionString) == 2 {
+		serverVersionString = serverVersionString + "0"
+	}
+
+	return strconv.Atoi(serverVersionString)
+}


### PR DESCRIPTION
LXD server version can be retrieved using the Go client. This avoids having the odd case of multipass commands in lxd.go and helps set up for future management of remote LXD instances.