### PR TITLE
Add new remotes backend to bravetools.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -84,6 +84,11 @@ func createBraveHome(userHome string) error {
 	if err != nil {
 		return err
 	}
+
+	err = shared.CreateDirectory(path.Join(userHome, shared.BraveRemoteStore))
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -129,6 +129,14 @@ func serverInit(cmd *cobra.Command, args []string) {
 	}
 
 	log.Println("Registering a Remote")
+	host.Remote = platform.NewBravehostRemote(host.Settings.BackendSettings)
+	err = platform.SaveRemote(host.Remote)
+	if err != nil {
+		if err := deleteBraveHome(userHome); err != nil {
+			fmt.Println(err.Error())
+		}
+		log.Fatal("failed to save default bravetools remote: ", err)
+	}
 	err = host.AddRemote()
 	if err != nil {
 		if err := deleteBraveHome(userHome); err != nil {

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"os/user"
@@ -29,7 +28,7 @@ import (
 
 // DeleteImageName deletes image by name
 func (bh *BraveHost) DeleteImageByName(name string) error {
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -47,7 +46,7 @@ func (bh *BraveHost) DeleteImageByName(name string) error {
 
 // DeleteImage delete image by fingerprint
 func (bh *BraveHost) DeleteImageByFingerprint(fingerprint string) error {
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -62,7 +61,7 @@ func (bh *BraveHost) DeleteImageByFingerprint(fingerprint string) error {
 
 // DeleteHostImages removes all LXC images from host
 func (bh *BraveHost) DeleteHostImages() error {
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -76,20 +75,9 @@ func (bh *BraveHost) DeleteHostImages() error {
 
 // AddRemote sets connection to Brave platform
 func (bh *BraveHost) AddRemote() error {
-	url := "https://" + bh.Settings.BackendSettings.Resources.IP + ":8443"
-	bh.Remote.url = url
-
-	err := RemoveRemote(bh.Settings.Name)
-	if err != nil {
-		fmt.Println("no Brave host. Continue adding a new host ..")
-	}
-	err = AddRemote(bh)
+	err := AddRemote(bh.Remote, bh.Settings.Trust)
 	if err != nil {
 		return errors.New("failed to add remote host: " + err.Error())
-	}
-
-	if err != nil {
-		log.Fatal("failed to access user home directory: ", err.Error())
 	}
 
 	return nil
@@ -302,7 +290,7 @@ func (bh *BraveHost) ListUnits(backend Backend) error {
 		return errors.New("cannot connect to Bravetools remote, ensure it is up and running")
 	}
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -359,7 +347,7 @@ func (bh *BraveHost) ListUnits(backend Backend) error {
 func (bh *BraveHost) UmountShare(unit string, target string) error {
 	backend := bh.Settings.BackendSettings.Type
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -416,7 +404,7 @@ func (bh *BraveHost) UmountShare(unit string, target string) error {
 // MountShare ..
 func (bh *BraveHost) MountShare(source string, destUnit string, destPath string) error {
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -523,7 +511,7 @@ func (bh *BraveHost) MountShare(source string, destUnit string, destPath string)
 func (bh *BraveHost) DeleteUnit(name string) error {
 	var unitNames []string
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -585,7 +573,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 		return errors.New("service Name is empty")
 	}
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -814,7 +802,7 @@ func (bh *BraveHost) PublishUnit(name string, backend Backend) error {
 		return errors.New("failed to get host info: " + err.Error())
 	}
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -851,7 +839,7 @@ func (bh *BraveHost) StopUnit(name string, backend Backend) error {
 		return errors.New("Backend is stopped")
 	}
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -875,7 +863,7 @@ func (bh *BraveHost) StartUnit(name string, backend Backend) error {
 		return errors.New("Backend is stopped")
 	}
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -900,7 +888,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 		return errors.New("unit image name cannot be empty")
 	}
 
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}
@@ -1119,7 +1107,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Bravefile) (er
 
 // Postdeploy copy files and run commands on running service
 func (bh *BraveHost) Postdeploy(ctx context.Context, bravefile *shared.Bravefile) (err error) {
-	lxdServer, err := GetLXDServer(bh.Remote)
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {
 		return err
 	}

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -1,0 +1,149 @@
+package platform
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/bravetools/bravetools/shared"
+)
+
+// Remote represents a configuration of the remote
+type Remote struct {
+	Name       string `json:"name"`
+	URL        string `json:"url"`
+	Protocol   string `json:"protocol"`
+	Public     bool   `json:"public"`
+	key        string
+	cert       string
+	servercert string
+}
+
+func NewBravehostRemote(settings BackendSettings) Remote {
+	var protocol string
+	var url string
+
+	switch settings.Type {
+	case "lxd":
+		protocol = "unix"
+		url = "/var/snap/lxd/common/lxd/unix.socket"
+	default:
+		protocol = "lxd"
+		url = "https://" + settings.Resources.IP + ":8443"
+	}
+
+	return Remote{
+		Name:     shared.BravetoolsRemote,
+		URL:      url,
+		Protocol: protocol,
+		Public:   false,
+	}
+}
+
+// loadRemoteConfig loads a saved bravetools remote config
+func loadRemoteConfig(name string) (remote Remote, err error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return remote, err
+	}
+
+	path := path.Join(home, shared.BraveRemoteStore, name+".json")
+
+	var fileBytes bytes.Buffer
+	f, err := os.Open(path)
+	if err != nil {
+		return remote, err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(&fileBytes, f)
+	if err != nil {
+		return remote, err
+	}
+
+	err = json.Unmarshal(fileBytes.Bytes(), &remote)
+	return remote, err
+}
+
+// LoadRemoteSettings loads a saved bravetools remote with TLS auth certs/keys if present
+func LoadRemoteSettings(remoteName string) (Remote, error) {
+
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return Remote{}, err
+	}
+
+	remote, err := loadRemoteConfig(remoteName)
+	if err != nil {
+		return Remote{}, err
+	}
+
+	// unix socket doesn't need any auth
+	if remote.Protocol == "unix" {
+		return remote, nil
+	}
+
+	// Load remote server cert for verification
+	serverCertPath := path.Join(userHome, shared.BraveServerCertStore, remoteName+".crt")
+	remote.servercert, _ = loadServerCert(serverCertPath)
+
+	// Public Image server doesn't need client auth
+	if remote.Public || remote.Protocol == "simplestreams" {
+		return remote, nil
+	}
+
+	// Add client cert and key
+	keyPath := path.Join(userHome, shared.BraveClientKey)
+	certPath := path.Join(userHome, shared.BraveClientCert)
+
+	remote.key, _ = loadKey(keyPath)
+	remote.cert, _ = loadCert(certPath)
+
+	return remote, nil
+}
+
+func SaveRemote(remote Remote) error {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to save remote %q: %s", remote.Name, err.Error())
+	}
+
+	path := path.Join(userHome, shared.BraveRemoteStore, remote.Name+".json")
+	remoteJson, err := json.MarshalIndent(remote, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, remoteJson, 0666)
+}
+
+func loadKey(path string) (string, error) {
+	buf, err := shared.ReadFile(path)
+	if err != nil {
+		return "", errors.New("cannot load client key")
+	}
+	key := buf.String()
+	return key, nil
+}
+
+func loadCert(path string) (string, error) {
+	buf, err := shared.ReadFile(path)
+	if err != nil {
+		return "", errors.New("cannot load client certificate")
+	}
+	cert := buf.String()
+	return cert, nil
+}
+
+func loadServerCert(path string) (string, error) {
+	buf, err := shared.ReadFile(path)
+	if err != nil {
+		return "", errors.New("cannot load server certificate")
+	}
+	cert := buf.String()
+	return cert, nil
+}

--- a/shared/constants.go
+++ b/shared/constants.go
@@ -21,6 +21,12 @@ const PlatformConfig = BraveHome + "/config.yml"
 // ImageStore ..
 const ImageStore = BraveHome + "/images/"
 
+// Bravetools local remote name
+const BravetoolsRemote = "bravetools"
+
+// BraveRemoteStore is path to remotes dir
+const BraveRemoteStore = BraveHome + "/remotes"
+
 // BraveClientKey ..
 const BraveClientKey = BraveCertStore + "/client.key"
 


### PR DESCRIPTION
Remotes are stored in a new "remotes" folder in bravetools home dir. A remote is a human-editable json file and associates a remote with a name, address, and protocol. TLS auth for a remote is loaded if necessary.

For now, the only remote is the default bravetools local remote created during init - if all works fine then next step is to expose the ability to select and create different remotes to users.

Multiple protocols are supported for backends, allowing for use of the Unix socket when running on Linux for less overhead. This also potentially allows for storing remote "simplestreams" image stores as remotes too.