### PR TITLE
Fix paths when copying dirs from Windows into Linux containers

### DIFF
--- a/platform/operations.go
+++ b/platform/operations.go
@@ -1254,7 +1254,7 @@ func CopyDirectory(lxdServer lxd.InstanceServer, name string, src, dst string) e
 	}
 	for _, entry := range entries {
 		source := filepath.Join(src, entry.Name())
-		destPath := filepath.Join(dst, entry.Name())
+		destPath := filepath.ToSlash(filepath.Join(dst, entry.Name()))
 
 		sourcePath := filepath.FromSlash(source)
 


### PR DESCRIPTION
Enforce forward slashes in path to destination within Linux container