### PR TITLE
Remote deployment

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -46,6 +46,7 @@ func init() {
 	BravetoolsCmd.AddCommand(baseBuild)
 	BravetoolsCmd.AddCommand(braveVersion)
 	BravetoolsCmd.AddCommand(braveCompose)
+	BravetoolsCmd.AddCommand(remoteCmd)
 
 	userHome, _ := os.UserHomeDir()
 	exists, err := shared.CheckPath(path.Join(userHome, shared.PlatformConfig))

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -31,6 +31,7 @@ func includeDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&deployArgs.IP, "ip", "i", "", "IPv4 address (e.g., 10.0.0.20) [OPTIONAL]")
 	cmd.Flags().StringVarP(&deployArgs.Resources.CPU, "cpu", "c", "", "Number of allocated CPUs (e.g., 2) [OPTIONAL]")
 	cmd.Flags().StringVarP(&deployArgs.Resources.RAM, "ram", "r", "", "Number of allocated CPUs (e.g., 2GB) [OPTIONAL]")
+	cmd.Flags().StringVarP(&deployArgs.Profile, "profile", "", "", "LXD profile to deploy to. Defaults to bravetools local profile [OPTIONAL]")
 	cmd.Flags().StringSliceVarP(&deployArgs.Ports, "port", "p", []string{}, "Publish Unit port to host [OPTIONAL]")
 	cmd.Flags().StringVarP(&deployArgs.Name, "name", "n", "", "Assign name to deployed Unit")
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -141,7 +141,7 @@ func serverInit(cmd *cobra.Command, args []string) {
 	}
 
 	log.Println("Registering a Remote")
-	host.Remote = platform.NewBravehostRemote(host.Settings.BackendSettings)
+	host.Remote = platform.NewBravehostRemote(host.Settings.BackendSettings, host.Settings.Profile)
 	err = platform.SaveRemote(host.Remote)
 	if err != nil {
 		if err := deleteBraveHome(userHome); err != nil {

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -1,0 +1,147 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/bravetools/bravetools/platform"
+	"github.com/bravetools/bravetools/shared"
+	"github.com/spf13/cobra"
+)
+
+var remoteCmd = &cobra.Command{
+	Use:   "remote",
+	Short: "Manage remotes",
+	Long:  ``,
+}
+
+var remoteAddCmd = &cobra.Command{
+	Use:   "add [NAME] [URL]",
+	Short: "Add a remote",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			cmd.Usage()
+			return fmt.Errorf("`brave remote add` expects two positional args, [NAME] and [URL], got %d", len(args))
+		}
+		return nil
+	},
+	Long: `Create a remote called [NAME] available at [URL].
+Example: brave remote add test https://localhost:8443`,
+	Run: remoteAdd,
+}
+
+var remoteRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a remote",
+	Long:  ``,
+	Args:  cobra.MinimumNArgs(1),
+	Run:   remoteRemove,
+}
+
+var remoteGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a remote",
+	Long:  "",
+	Args:  cobra.ExactArgs(1),
+	Run:   remoteGet,
+}
+
+var remoteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all remotes",
+	Long:  "",
+	Args:  cobra.NoArgs,
+	Run:   remoteList,
+}
+
+var remoteArgs = &platform.Remote{}
+var remotePassword = ""
+
+func init() {
+	remoteCmd.AddCommand(remoteAddCmd)
+	remoteCmd.AddCommand(remoteRemoveCmd)
+	remoteCmd.AddCommand(remoteGetCmd)
+	remoteCmd.AddCommand(remoteListCmd)
+	includeRemoteAddFlags(remoteAddCmd)
+}
+
+func includeRemoteAddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&remoteArgs.Protocol, "protocol", "lxd", "LXD server protocol to connect with (e.g. 'lxd', 'simplestreams')")
+	cmd.Flags().BoolVar(&remoteArgs.Public, "public", false, "Publicly available server with no authentication")
+	cmd.Flags().StringVar(&remoteArgs.Profile, "profile", "", "Name of LXD profile to use with this remote by default (e.g. 'bravetools')")
+	cmd.Flags().StringVar(&remotePassword, "password", "", "Trusted password to use when communicating with remote")
+}
+
+func remoteAdd(cmd *cobra.Command, args []string) {
+
+	remoteArgs.Name = args[0]
+	remoteArgs.URL = args[1]
+
+	err := platform.SaveRemote(*remoteArgs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Need to generate certs for non-public remotes
+	if !remoteArgs.Public && !(remoteArgs.Protocol == "unix") {
+
+		if remotePassword == "" {
+			log.Println("adding a non-public remote without providing a trusted password with the --password flag only works with remotes that already trust bravetools")
+		}
+
+		err = platform.AddRemote(*remoteArgs, remotePassword)
+		if err != nil {
+			platform.RemoveRemote(remoteArgs.Name)
+			log.Fatal(err)
+		}
+	} else {
+		// Validate public/unix connection
+		if remoteArgs.Protocol == "unix" {
+			_, err = platform.GetLXDInstanceServer(*remoteArgs)
+		} else {
+			_, err = platform.GetLXDImageSever(*remoteArgs)
+		}
+
+		if err != nil {
+			platform.RemoveRemote(remoteArgs.Name)
+			log.Fatal(err)
+		}
+	}
+}
+
+func remoteRemove(cmd *cobra.Command, args []string) {
+	for _, arg := range args {
+		if arg == shared.BravetoolsRemote {
+			log.Printf("remote %q cannot be removed, skipping", arg)
+			continue
+		}
+
+		err := platform.RemoveRemote(arg)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func remoteGet(cmd *cobra.Command, args []string) {
+	remote, err := platform.LoadRemoteSettings(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	remoteJson, err := json.MarshalIndent(remote, "", "    ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(remoteJson))
+}
+
+func remoteList(cmd *cobra.Command, args []string) {
+	remoteNames, err := platform.ListRemotes()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, name := range remoteNames {
+		fmt.Println(name)
+	}
+}

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -129,11 +129,11 @@ func createSharedVolume(lxdServer lxd.InstanceServer,
 	return nil
 }
 
-func importLXD(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile) (fingerprint string, err error) {
+func importLXD(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, profileName string) (fingerprint string, err error) {
 	if err = ctx.Err(); err != nil {
 		return "", err
 	}
-	fingerprint, err = Launch(ctx, lxdServer, bravefile.PlatformService.Name, bravefile.Base.Image)
+	fingerprint, err = Launch(ctx, lxdServer, bravefile.PlatformService.Name, bravefile.Base.Image, profileName)
 	if err != nil {
 		return fingerprint, errors.New("failed to launch base unit: " + err.Error())
 	}
@@ -141,7 +141,7 @@ func importLXD(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *sha
 	return fingerprint, nil
 }
 
-func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, bh *BraveHost) (fingerprint string, err error) {
+func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, bh *BraveHost, profileName string) (fingerprint string, err error) {
 	if err = ctx.Err(); err != nil {
 		return "", err
 	}
@@ -171,11 +171,11 @@ func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *
 	remoteBravefile.Base.Image = remoteServiceName
 	remoteBravefile.PlatformService.Name = bravefile.PlatformService.Name
 
-	fingerprint, err = importLocal(ctx, lxdServer, remoteBravefile)
+	fingerprint, err = importLocal(ctx, lxdServer, remoteBravefile, profileName)
 	return fingerprint, err
 }
 
-func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile) (fingerprint string, err error) {
+func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, profileName string) (fingerprint string, err error) {
 	if err = ctx.Err(); err != nil {
 		return "", err
 	}
@@ -196,7 +196,7 @@ func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *s
 		return fingerprint, err
 	}
 
-	err = LaunchFromImage(lxdServer, bravefile.Base.Image, bravefile.PlatformService.Name)
+	err = LaunchFromImage(lxdServer, bravefile.Base.Image, bravefile.PlatformService.Name, profileName)
 	if err != nil {
 		return fingerprint, errors.New("failed to launch unit: " + err.Error())
 	}
@@ -456,13 +456,13 @@ func addIPRules(lxdServer lxd.InstanceServer, ct string, hostPort string, ctPort
 	return nil
 }
 
-func checkUnits(lxdServer lxd.InstanceServer, unitName string) error {
+func checkUnits(lxdServer lxd.InstanceServer, unitName string, profileName string) error {
 	if unitName == "" {
 		return errors.New("unit name cannot be empty")
 	}
 
 	// Unit Checks
-	unitList, err := GetUnits(lxdServer)
+	unitList, err := GetUnits(lxdServer, profileName)
 	if err != nil {
 		return err
 	}

--- a/platform/host.go
+++ b/platform/host.go
@@ -185,8 +185,7 @@ func ConfigureHost(settings HostSettings, remote Remote) error {
 	if err != nil {
 		return err
 	}
-
-	units, err := GetUnits(lxdServer)
+	units, err := GetUnits(lxdServer, settings.Profile)
 	if err != nil {
 		return errors.New("failed to list units: " + err.Error())
 	}

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -329,25 +329,13 @@ func GetVolume(lxdServer lxd.InstanceServer, pool string) (volume api.StorageVol
 }
 
 // GetBraveProfile ..
-func GetBraveProfile(lxdServer lxd.InstanceServer) (braveProfile shared.BraveProfile, err error) {
+func GetBraveProfile(lxdServer lxd.InstanceServer, profileName string) (braveProfile shared.BraveProfile, err error) {
 	srv, _, err := lxdServer.GetServer()
 	if err != nil {
 		log.Fatal("LXD server error: " + err.Error())
 	}
 	braveProfile.LxdVersion = srv.Environment.ServerVersion
 	pNames, _ := lxdServer.GetProfileNames()
-
-	host, err := NewBraveHost()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	profileName := host.Settings.Profile
-
-	//profileName, err := getCurrentUsername()
-	//if err != nil {
-	//	log.Fatal(err.Error())
-	//}
 
 	for _, pName := range pNames {
 		if pName == profileName {
@@ -367,9 +355,9 @@ func GetBraveProfile(lxdServer lxd.InstanceServer) (braveProfile shared.BravePro
 	return braveProfile, errors.New("profile not found")
 }
 
-func containerHasProfile(container *api.Container, profile *shared.BraveProfile) bool {
+func containerHasProfile(container *api.Container, profileName string) bool {
 	for _, p := range container.ContainerPut.Profiles {
-		if p == profile.Name {
+		if p == profileName {
 			return true
 		}
 	}
@@ -377,12 +365,7 @@ func containerHasProfile(container *api.Container, profile *shared.BraveProfile)
 }
 
 // GetUnits returns all running units
-func GetUnits(lxdServer lxd.InstanceServer) (units []shared.BraveUnit, err error) {
-	userProfile, err := GetBraveProfile(lxdServer)
-	if err != nil {
-		return nil, err
-	}
-
+func GetUnits(lxdServer lxd.InstanceServer, profileName string) (units []shared.BraveUnit, err error) {
 	names, err := lxdServer.GetContainerNames()
 	if err != nil {
 		return nil, err
@@ -392,8 +375,8 @@ func GetUnits(lxdServer lxd.InstanceServer) (units []shared.BraveUnit, err error
 		var unit shared.BraveUnit
 		container, _, _ := lxdServer.GetContainer(n)
 
-		// Check if current user profile manages this container
-		if !containerHasProfile(container, &userProfile) {
+		// Check if selected user profile manages this container
+		if !containerHasProfile(container, profileName) {
 			continue
 		}
 
@@ -446,7 +429,7 @@ func GetUnits(lxdServer lxd.InstanceServer) (units []shared.BraveUnit, err error
 }
 
 // LaunchFromImage creates new unit based on image
-func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string) error {
+func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string, profileName string) error {
 	operation := shared.Info("Launching " + name)
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 	s.Suffix = " " + operation
@@ -461,18 +444,6 @@ func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string) er
 		return err
 	}
 	req.Source.Alias = name
-
-	host, err := NewBraveHost()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	profileName := host.Settings.Profile
-
-	//profileName, err := getCurrentUsername()
-	//if err != nil {
-	//	log.Fatal(err.Error())
-	//}
 	req.Profiles = []string{profileName}
 
 	image = alias.Target
@@ -499,7 +470,7 @@ func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string) er
 // Launch starts a new unit based on standard image from linuxcontainers.org
 // Alias: "ubuntu/bionic/amd64"
 // Alias: "alpine/3.9/amd64"
-func Launch(ctx context.Context, localLxd lxd.InstanceServer, name string, alias string) (fingerprint string, err error) {
+func Launch(ctx context.Context, localLxd lxd.InstanceServer, name string, alias string, profileName string) (fingerprint string, err error) {
 	if err = ctx.Err(); err != nil {
 		return fingerprint, err
 	}
@@ -537,16 +508,6 @@ func Launch(ctx context.Context, localLxd lxd.InstanceServer, name string, alias
 			Fingerprint: fingerprint,
 		},
 	}
-
-	host, err := NewBraveHost()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	profileName := host.Settings.Profile
-	//profileName, err := getCurrentUsername()
-	//if err != nil {
-	//	log.Fatal(err.Error())
-	//}
 
 	req.Profiles = []string{profileName}
 

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/bravetools/bravetools/shared"
 )
@@ -42,6 +43,17 @@ func NewBravehostRemote(settings BackendSettings) Remote {
 		Protocol: protocol,
 		Public:   false,
 	}
+}
+
+// ParseRemoteName unpacks remote and rest of image/service name and returns both
+func ParseRemoteName(image string) (remote string, imageName string) {
+	split := strings.SplitN(image, ":", 2)
+	if len(split) == 1 {
+		// Default remote
+		return shared.BravetoolsRemote, split[0]
+	}
+
+	return split[0], split[1]
 }
 
 // loadRemoteConfig loads a saved bravetools remote config

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/bravetools/bravetools/shared"
@@ -133,6 +134,25 @@ func SaveRemote(remote Remote) error {
 	}
 
 	return os.WriteFile(path, remoteJson, 0666)
+}
+
+func ListRemotes() (names []string, err error) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return names, errors.New("failed to list remotes: " + err.Error())
+	}
+
+	dir, err := os.Open(path.Join(userHome, shared.BraveRemoteStore))
+	if err != nil {
+		return names, errors.New("failed to list remotes: " + err.Error())
+	}
+
+	names, err = dir.Readdirnames(-1)
+	for i := range names {
+		names[i] = strings.TrimSuffix(names[i], filepath.Ext(names[i]))
+	}
+
+	return names, err
 }
 
 func loadKey(path string) (string, error) {

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -19,12 +19,13 @@ type Remote struct {
 	URL        string `json:"url"`
 	Protocol   string `json:"protocol"`
 	Public     bool   `json:"public"`
+	Profile    string `json:"profile"`
 	key        string
 	cert       string
 	servercert string
 }
 
-func NewBravehostRemote(settings BackendSettings) Remote {
+func NewBravehostRemote(settings BackendSettings, profileName string) Remote {
 	var protocol string
 	var url string
 
@@ -42,6 +43,7 @@ func NewBravehostRemote(settings BackendSettings) Remote {
 		URL:      url,
 		Protocol: protocol,
 		Public:   false,
+		Profile:  profileName,
 	}
 }
 

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -43,6 +43,7 @@ type Service struct {
 	Name       string     `yaml:"name,omitempty"`
 	Image      string     `yaml:"image,omitempty"`
 	Version    string     `yaml:"version,omitempty"`
+	Profile    string     `yaml:"profile,omitempty"`
 	Docker     string     `yaml:"docker,omitempty"`
 	IP         string     `yaml:"ip"`
 	Ports      []string   `yaml:"ports"`


### PR DESCRIPTION
Enables users to specify the remote to deploy to using the unit name. The first section of the unit named preceding the colon ":" will be taken as the remote name. If no remote is specified the default bravetools local remote will be used.

For example, the following Bravefile snippet will deploy a unit called "example" at the "test" remote:
```yaml:
service:
    name: test:example
    ...
```

Also included in this is a way to specify which LXD profile to deploy the unit using, since we can no longer assume the local profile will exist on remotes. This profile can be specified in the Bravefile Service section or using a CLI flag `brave deploy --profile [name]`. If no profile is specified, the remote's default profile saved at ~/.bravetools/remotes will be used.