### PR TITLE
add default remote name to global config

### DIFF
--- a/platform/host.go
+++ b/platform/host.go
@@ -24,6 +24,7 @@ type HostSettings struct {
 	Network         Network         `yaml:"network"`
 	BackendSettings BackendSettings `yaml:"backendsettings"`
 	Status          string          `yaml:"status"`
+	Remote          string          `yaml:"remote"`
 }
 
 // Storage ..
@@ -76,7 +77,7 @@ func NewBraveHost() (*BraveHost, error) {
 	}
 
 	// Load host remote if initialized
-	host.Remote, _ = LoadRemoteSettings(shared.BravetoolsRemote)
+	host.Remote, _ = LoadRemoteSettings(host.Settings.Remote)
 
 	host.Backend, err = NewHostBackend(host.Settings)
 	if err != nil {
@@ -148,6 +149,8 @@ func SetupHostConfiguration(params HostConfig, userHome string) (settings HostSe
 		}
 		settings.BackendSettings = backendSettings
 	}
+
+	settings.Remote = shared.BravetoolsRemote
 
 	doc, err := yaml.Marshal(settings)
 	if err != nil {

--- a/platform/host.go
+++ b/platform/host.go
@@ -246,5 +246,9 @@ func loadHostSettings(userHome string) (HostSettings, error) {
 		return settings, errors.New("failed to parse configuration yaml: " + err.Error())
 	}
 
+	if settings.Remote == "" {
+		settings.Remote = shared.BravetoolsRemote
+	}
+
 	return settings, nil
 }


### PR DESCRIPTION
This pull request enables brave tools to build on remote LXD instances.

Default remote name can be specified In $HOME/.bravetools/config.yml and is used by brave tools to execute instructions on  pre-configured remotes.

name: user
trust: user
profile: user
storage:
  type: zfs
  name: user-20220903104341
  size: 98GB
network:
  bridge: 10.118.99.1
backendsettings:
  type: multipass
  resources:
    name: user
    os: bionic
    cpu: "2"
    ram: 4GB
    hd: 100GB
    ip: 192.168.64.56
status: active
remote: REMOTE_NAME 
```