### PR TITLE
Remote lxd resources

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -34,6 +34,7 @@ func includeDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&deployArgs.Profile, "profile", "", "", "LXD profile to deploy to. Defaults to bravetools local profile [OPTIONAL]")
 	cmd.Flags().StringSliceVarP(&deployArgs.Ports, "port", "p", []string{}, "Publish Unit port to host [OPTIONAL]")
 	cmd.Flags().StringVarP(&deployArgs.Name, "name", "n", "", "Assign name to deployed Unit")
+	cmd.Flags().StringVar(&deployArgs.Network, "network", "", "LXD-managed bridge to use for networking containers (e.g. lxdbr0)")
 }
 
 func deploy(cmd *cobra.Command, args []string) {

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -35,6 +35,7 @@ func includeDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&deployArgs.Ports, "port", "p", []string{}, "Publish Unit port to host [OPTIONAL]")
 	cmd.Flags().StringVarP(&deployArgs.Name, "name", "n", "", "Assign name to deployed Unit")
 	cmd.Flags().StringVar(&deployArgs.Network, "network", "", "LXD-managed bridge to use for networking containers (e.g. lxdbr0)")
+	cmd.Flags().StringVar(&deployArgs.Storage, "storage", "", "Name of LXD storage pool to use for container")
 }
 
 func deploy(cmd *cobra.Command, args []string) {

--- a/commands/init.go
+++ b/commands/init.go
@@ -141,7 +141,7 @@ func serverInit(cmd *cobra.Command, args []string) {
 	}
 
 	log.Println("Registering a Remote")
-	host.Remote = platform.NewBravehostRemote(host.Settings.BackendSettings, host.Settings.Profile)
+	host.Remote = platform.NewBravehostRemote(host.Settings)
 	err = platform.SaveRemote(host.Remote)
 	if err != nil {
 		if err := deleteBraveHome(userHome); err != nil {

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -70,7 +70,7 @@ func includeRemoteAddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&remoteArgs.Protocol, "protocol", "lxd", "LXD server protocol to connect with (e.g. 'lxd', 'simplestreams')")
 	cmd.Flags().BoolVar(&remoteArgs.Public, "public", false, "Publicly available server with no authentication")
 	cmd.Flags().StringVar(&remoteArgs.Profile, "profile", "", "Name of LXD profile to use with this remote by default (e.g. 'bravetools')")
-	cmd.Flags().StringVar(&remoteArgs.Bridge, "bridge", "", "LXD-managed bridge to use for networking containers (e.g. lxdbr0)")
+	cmd.Flags().StringVar(&remoteArgs.Network, "network", "", "LXD-managed bridge to use for networking containers (e.g. lxdbr0)")
 	cmd.Flags().StringVar(&remotePassword, "password", "", "Trusted password to use when communicating with remote")
 }
 

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -70,6 +70,7 @@ func includeRemoteAddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&remoteArgs.Protocol, "protocol", "lxd", "LXD server protocol to connect with (e.g. 'lxd', 'simplestreams')")
 	cmd.Flags().BoolVar(&remoteArgs.Public, "public", false, "Publicly available server with no authentication")
 	cmd.Flags().StringVar(&remoteArgs.Profile, "profile", "", "Name of LXD profile to use with this remote by default (e.g. 'bravetools')")
+	cmd.Flags().StringVar(&remoteArgs.Bridge, "bridge", "", "LXD-managed bridge to use for networking containers (e.g. lxdbr0)")
 	cmd.Flags().StringVar(&remotePassword, "password", "", "Trusted password to use when communicating with remote")
 }
 

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -71,6 +71,7 @@ func includeRemoteAddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&remoteArgs.Public, "public", false, "Publicly available server with no authentication")
 	cmd.Flags().StringVar(&remoteArgs.Profile, "profile", "", "Name of LXD profile to use with this remote by default (e.g. 'bravetools')")
 	cmd.Flags().StringVar(&remoteArgs.Network, "network", "", "LXD-managed bridge to use for networking containers (e.g. lxdbr0)")
+	cmd.Flags().StringVar(&remoteArgs.Storage, "storage", "", "Name of LXD storage pool to use for container")
 	cmd.Flags().StringVar(&remotePassword, "password", "", "Trusted password to use when communicating with remote")
 }
 

--- a/docs/docs/bravefile.md
+++ b/docs/docs/bravefile.md
@@ -87,6 +87,7 @@ Controls image properties, such as name, version, and run-time configuration. It
 ```yaml
 service:
   name: alpine-edge-bazel
+  image: alpine-edge-bazel-0.27.1
   profile: brave
   network: lxdbr0
   storage: brave-deploy-disk

--- a/docs/docs/bravefile.md
+++ b/docs/docs/bravefile.md
@@ -87,6 +87,9 @@ Controls image properties, such as name, version, and run-time configuration. It
 ```yaml
 service:
   name: alpine-edge-bazel
+  profile: brave
+  network: lxdbr0
+  storage: brave-deploy-disk
   version: 0.27.1
   ip: ""
   ports: []

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -141,7 +141,7 @@ func importLXD(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *sha
 	return fingerprint, nil
 }
 
-func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, bh *BraveHost, profileName string) (fingerprint string, err error) {
+func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, bh *BraveHost, profileName string, storagePool string) (fingerprint string, err error) {
 	if err = ctx.Err(); err != nil {
 		return "", err
 	}
@@ -171,11 +171,11 @@ func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *
 	remoteBravefile.Base.Image = remoteServiceName
 	remoteBravefile.PlatformService.Name = bravefile.PlatformService.Name
 
-	fingerprint, err = importLocal(ctx, lxdServer, remoteBravefile, profileName)
+	fingerprint, err = importLocal(ctx, lxdServer, remoteBravefile, profileName, storagePool)
 	return fingerprint, err
 }
 
-func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, profileName string) (fingerprint string, err error) {
+func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *shared.Bravefile, profileName string, storagePool string) (fingerprint string, err error) {
 	if err = ctx.Err(); err != nil {
 		return "", err
 	}
@@ -196,7 +196,7 @@ func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *s
 		return fingerprint, err
 	}
 
-	err = LaunchFromImage(lxdServer, bravefile.Base.Image, bravefile.PlatformService.Name, profileName)
+	err = LaunchFromImage(lxdServer, bravefile.Base.Image, bravefile.PlatformService.Name, profileName, storagePool)
 	if err != nil {
 		return fingerprint, errors.New("failed to launch unit: " + err.Error())
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -910,6 +910,13 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 		unitParams.Storage = deployRemote.Storage
 	}
 
+	// As last resort if not provided in Bravefile or remote, try the Brave host settings - mostly for backward compatability
+	if unitParams.Profile == "" && unitParams.Network == "" && unitParams.Storage == "" {
+		unitParams.Profile = bh.Settings.Profile
+		unitParams.Network = bh.Settings.Name
+		unitParams.Storage = bh.Settings.StoragePool.Name
+	}
+
 	lxdServer, err := GetLXDInstanceServer(deployRemote)
 	if err != nil {
 		return err

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -644,7 +644,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			return err
 		}
 	case "github":
-		imageFingerprint, err = importGitHub(ctx, lxdServer, bravefile, bh, bh.Remote.Profile)
+		imageFingerprint, err = importGitHub(ctx, lxdServer, bravefile, bh, bh.Remote.Profile, bh.Remote.Storage)
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return err
 		}
@@ -664,7 +664,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			return err
 		}
 
-		imageFingerprint, err = importLocal(ctx, lxdServer, bravefile, bh.Remote.Profile)
+		imageFingerprint, err = importLocal(ctx, lxdServer, bravefile, bh.Remote.Profile, bh.Remote.Storage)
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return err
 		}
@@ -906,6 +906,9 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 	if unitParams.Network == "" {
 		unitParams.Network = deployRemote.Network
 	}
+	if unitParams.Storage == "" {
+		unitParams.Storage = deployRemote.Storage
+	}
 
 	lxdServer, err := GetLXDInstanceServer(deployRemote)
 	if err != nil {
@@ -959,7 +962,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 	}
 
 	// Launch unit and set up cleanup code to delete it if an error encountered during deployment
-	err = LaunchFromImage(lxdServer, unitName, unitName, unitParams.Profile)
+	err = LaunchFromImage(lxdServer, unitName, unitName, unitParams.Profile, unitParams.Storage)
 	defer func() {
 		if err != nil {
 			delErr := DeleteUnit(lxdServer, unitName)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -969,7 +969,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 		return errors.New("failed to launch unit: " + err.Error())
 	}
 
-	err = AttachNetwork(lxdServer, unitName, deployRemote.Bridge, "eth0", "eth0")
+	err = AttachNetwork(lxdServer, unitName, deployRemote.Network, "eth0", "eth0")
 	if err = shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("failed to attach network: " + err.Error())
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -969,7 +969,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 		return errors.New("failed to launch unit: " + err.Error())
 	}
 
-	err = AttachNetwork(lxdServer, unitName, bh.Settings.Name+"br0", "eth0", "eth0")
+	err = AttachNetwork(lxdServer, unitName, deployRemote.Bridge, "eth0", "eth0")
 	if err = shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("failed to attach network: " + err.Error())
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -899,9 +899,12 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 		return fmt.Errorf("failed to load remote %q for requested unit %q: %s", deployRemoteName, unitName, err.Error())
 	}
 
-	// Deployment LXD profile - if not specified use remote default profile
+	// Load remote defaults for LXD resources for deployment (profile, network, storage) if not specified in Bravefile unitParams
 	if unitParams.Profile == "" {
 		unitParams.Profile = deployRemote.Profile
+	}
+	if unitParams.Network == "" {
+		unitParams.Network = deployRemote.Network
 	}
 
 	lxdServer, err := GetLXDInstanceServer(deployRemote)
@@ -969,11 +972,12 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 		return errors.New("failed to launch unit: " + err.Error())
 	}
 
-	err = AttachNetwork(lxdServer, unitName, deployRemote.Network, "eth0", "eth0")
+	err = AttachNetwork(lxdServer, unitName, unitParams.Network, "eth0", "eth0")
 	if err = shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("failed to attach network: " + err.Error())
 	}
 
+	// Assign static IP
 	err = ConfigDevice(lxdServer, unitName, "eth0", unitParams.IP)
 	if err = shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("failed to set IP: " + err.Error())

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -483,11 +483,14 @@ func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string, pr
 
 	// Attach a specific disk when launching if requested
 	if storagePool != "" {
-		pool, _, err := lxdServer.GetStoragePool(storagePool)
-		if err != nil {
-			return err
+		if req.Devices == nil {
+			req.Devices = make(map[string]map[string]string)
 		}
-		req.Devices[storagePool] = pool.Writable().Config
+		req.Devices["root"] = map[string]string{
+			"path": "/",
+			"pool": storagePool,
+			"type": "disk",
+		}
 	}
 
 	image = alias.Target

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -464,7 +464,7 @@ func GetUnits(lxdServer lxd.InstanceServer, profileName string) (units []shared.
 }
 
 // LaunchFromImage creates new unit based on image
-func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string, profileName string) error {
+func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string, profileName string, storagePool string) error {
 	operation := shared.Info("Launching " + name)
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 	s.Suffix = " " + operation
@@ -480,6 +480,15 @@ func LaunchFromImage(lxdServer lxd.InstanceServer, image string, name string, pr
 	}
 	req.Source.Alias = name
 	req.Profiles = []string{profileName}
+
+	// Attach a specific disk when launching if requested
+	if storagePool != "" {
+		pool, _, err := lxdServer.GetStoragePool(storagePool)
+		if err != nil {
+			return err
+		}
+		req.Devices[storagePool] = pool.Writable().Config
+	}
 
 	image = alias.Target
 	imgInfo, _, err := lxdServer.GetImage(image)

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -21,22 +21,23 @@ type Remote struct {
 	Protocol   string `json:"protocol"`
 	Public     bool   `json:"public"`
 	Profile    string `json:"profile"`
+	Bridge     string `json:"bridge"`
 	key        string
 	cert       string
 	servercert string
 }
 
-func NewBravehostRemote(settings BackendSettings, profileName string) Remote {
+func NewBravehostRemote(settings HostSettings) Remote {
 	var protocol string
 	var url string
 
-	switch settings.Type {
+	switch settings.BackendSettings.Type {
 	case "lxd":
 		protocol = "unix"
 		url = "/var/snap/lxd/common/lxd/unix.socket"
 	default:
 		protocol = "lxd"
-		url = "https://" + settings.Resources.IP + ":8443"
+		url = "https://" + settings.BackendSettings.Resources.IP + ":8443"
 	}
 
 	return Remote{
@@ -44,7 +45,8 @@ func NewBravehostRemote(settings BackendSettings, profileName string) Remote {
 		URL:      url,
 		Protocol: protocol,
 		Public:   false,
-		Profile:  profileName,
+		Profile:  settings.Profile,
+		Bridge:   settings.Network.Bridge,
 	}
 }
 

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -22,6 +22,7 @@ type Remote struct {
 	Public     bool   `json:"public"`
 	Profile    string `json:"profile"`
 	Network    string `json:"network"`
+	Storage    string `json:"storage"`
 	key        string
 	cert       string
 	servercert string
@@ -47,6 +48,7 @@ func NewBravehostRemote(settings HostSettings) Remote {
 		Public:   false,
 		Profile:  settings.Profile,
 		Network:  settings.Network.Bridge,
+		Storage:  settings.StoragePool.Name,
 	}
 }
 

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -21,7 +21,7 @@ type Remote struct {
 	Protocol   string `json:"protocol"`
 	Public     bool   `json:"public"`
 	Profile    string `json:"profile"`
-	Bridge     string `json:"bridge"`
+	Network    string `json:"network"`
 	key        string
 	cert       string
 	servercert string
@@ -46,7 +46,7 @@ func NewBravehostRemote(settings HostSettings) Remote {
 		Protocol: protocol,
 		Public:   false,
 		Profile:  settings.Profile,
-		Bridge:   settings.Network.Bridge,
+		Network:  settings.Network.Bridge,
 	}
 }
 

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -131,6 +131,15 @@ func (s *Service) Merge(service *Service) {
 	if s.Version == "" {
 		s.Version = service.Version
 	}
+	if s.Profile == "" {
+		s.Profile = service.Profile
+	}
+	if s.Network == "" {
+		s.Network = service.Network
+	}
+	if s.Storage == "" {
+		s.Storage = service.Storage
+	}
 	if s.Docker == "" {
 		s.Docker = service.Docker
 	}

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -44,6 +44,7 @@ type Service struct {
 	Image      string     `yaml:"image,omitempty"`
 	Version    string     `yaml:"version,omitempty"`
 	Profile    string     `yaml:"profile,omitempty"`
+	Storage    string     `yaml:"storage,omitempty"`
 	Network    string     `yaml:"network,omitempty"`
 	Docker     string     `yaml:"docker,omitempty"`
 	IP         string     `yaml:"ip"`

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -44,6 +44,7 @@ type Service struct {
 	Image      string     `yaml:"image,omitempty"`
 	Version    string     `yaml:"version,omitempty"`
 	Profile    string     `yaml:"profile,omitempty"`
+	Network    string     `yaml:"network,omitempty"`
 	Docker     string     `yaml:"docker,omitempty"`
 	IP         string     `yaml:"ip"`
 	Ports      []string   `yaml:"ports"`


### PR DESCRIPTION
Adds ability to customize the resources an LXD container uses when deployed (Network/Storage). Primarily this allows for customizing these resources for different remote deployment targets.

Changes:
- Can specify Network/Storage/Profile to be used for deplyoment in Bravefile Service section or deploy CLI command
- Can associate a default Profile/Network/Storage with a remote, which will be used if none provided in Bravefile/CLI
- If Profile/Network/Storage still not provided, loads Host configured Profile/Network/Storage for backwards compatability

Note that selecting a disk device to launch the container with will show up when running `brave units`.
```sh
brave units

NAME            STATUS  IPV4            VOLUMES         PORTS
mongodb-amd64   Running 10.0.0.25       root:->/        27017:27017
```