### PR TITLE
Listing remote units

### DIFF
--- a/commands/units.go
+++ b/commands/units.go
@@ -7,15 +7,24 @@ import (
 )
 
 var braveListUnits = &cobra.Command{
-	Use:   "units",
+	Use:   "units [NAME]",
 	Short: "List Units",
-	Long:  `This function returns a list of all Units deployed on a remote Bravetools host`,
-	Run:   units,
+	Long: `This function returns a list of all Units deployed on a remote Bravetools host. 
+
+If a specific remote is not specified, all units across all remotes will be returned.`,
+	Run:  units,
+	Args: cobra.RangeArgs(0, 1),
 }
 
 func units(cmd *cobra.Command, args []string) {
 	checkBackend()
-	err := host.ListUnits(backend)
+
+	remoteName := ""
+	if len(args) == 1 {
+		remoteName = args[0]
+	}
+
+	err := host.ListUnits(backend, remoteName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"os/user"
@@ -328,7 +329,8 @@ func (bh *BraveHost) ListUnits(backend Backend, remoteName string) error {
 
 			lxdServer, err := GetLXDInstanceServer(deployRemote)
 			if err != nil {
-				return err
+				log.Printf("failed to connect to %q remote, skipping", deployRemote.Name)
+				continue
 			}
 
 			remoteUnits, err := GetUnits(lxdServer, deployRemote.Profile)

--- a/shared/constants.go
+++ b/shared/constants.go
@@ -23,7 +23,7 @@ const PlatformConfig = BraveHome + "/config.yml"
 const ImageStore = BraveHome + "/images/"
 
 // Bravetools local remote name
-const BravetoolsRemote = "bravetools"
+const BravetoolsRemote = "local"
 
 // BraveRemoteStore is path to remotes dir
 const BraveRemoteStore = BraveHome + "/remotes"


### PR DESCRIPTION
Addressing https://github.com/bravetools/bravetools/issues/148, this allows for listing remote units managed by bravetools.

`brave units` now lists all units across all remotes when called with no args. Each unit will be prefixed by the remote name with a colon. If a specific remote is provided, only units on that remote will be listed (with no prefix).

The remote units are identified by the profile stored with that remote to separate them from other LXD containers that bravetools does not manage. (This does mean it is preferable to assign a profile when adding a new remote).


Example:
```sh
brave units

NAME                            STATUS  IPV4            VOLUMES                         PORTS
local:mongodb-amd64             Running 10.0.0.25       root:->/                        27017:27017

deploy:mongodb-amd64            Running 20.0.0.27                                       27017:27017
```

### Problems
There is an issue with this change - it requries all deploy remotes that are stored to be contactable when you run `brave units` otherwise it will take a while attempting connect to a remote it cannot reach before erroring out.

An alternative way of handling it may be to continue without error if unable to connect to a remote, if we don't mind silently skipping over non-reachable remotes. We might need to lower the timeout for connecting to a remote server too, else the command will take a while.