### PR TITLE
Network storage bugfix

### DIFF
--- a/platform/host.go
+++ b/platform/host.go
@@ -37,7 +37,7 @@ type Storage struct {
 // Network ..
 type Network struct {
 	Name string `yaml:"name"`
-	IP   string `yaml:"bridge"`
+	IP   string `yaml:"ip"`
 }
 
 // BackendSettings ..

--- a/platform/host.go
+++ b/platform/host.go
@@ -36,7 +36,8 @@ type Storage struct {
 
 // Network ..
 type Network struct {
-	Bridge string `yaml:"bridge"`
+	Name string `yaml:"name"`
+	IP   string `yaml:"bridge"`
 }
 
 // BackendSettings ..
@@ -107,6 +108,8 @@ func SetupHostConfiguration(params HostConfig, userHome string) (settings HostSe
 	timestamp := time.Now()
 	storagePoolName := hostName + "-" + timestamp.Format("20060102150405")
 
+	networkBridgeName := hostName + "br0"
+
 	settings = HostSettings{
 		Name:    hostName,
 		Trust:   hostName,
@@ -117,7 +120,8 @@ func SetupHostConfiguration(params HostConfig, userHome string) (settings HostSe
 			Size: strconv.Itoa(poolSizeInt) + "GB",
 		},
 		Network: Network{
-			Bridge: params.Network,
+			Name: networkBridgeName,
+			IP:   params.Network,
 		},
 		Status: "inactive",
 	}

--- a/platform/lxd.go
+++ b/platform/lxd.go
@@ -142,13 +142,13 @@ func initiateLxd(vm Lxd, whichLxc string) error {
 		return errors.New("failed to create storage pool: " + err.Error())
 	}
 
-	bridge := "ipv4.address=" + vm.Settings.Network.Bridge + "/24"
+	bridge := "ipv4.address=" + vm.Settings.Network.IP + "/24"
 
 	err = shared.ExecCommand(
 		whichLxc,
 		"network",
 		"create",
-		vm.Settings.Profile+"br0",
+		vm.Settings.Network.Name,
 		"ipv6.address=none",
 		bridge,
 		"ipv4.nat=true")
@@ -163,13 +163,13 @@ func initiateLxd(vm Lxd, whichLxc string) error {
 		whichLxc,
 		"network",
 		"attach-profile",
-		vm.Settings.Profile+"br0",
+		vm.Settings.Network.Name,
 		vm.Settings.Profile,
 		"eth0")
 	if err != nil {
 		_ = shared.ExecCommand(whichLxc, "profile", "delete", vm.Settings.Profile)
 		_ = shared.ExecCommand(whichLxc, "storage", "delete", vm.Settings.StoragePool.Name)
-		_ = shared.ExecCommand(whichLxc, "network", "delete", vm.Settings.Profile+"br0")
+		_ = shared.ExecCommand(whichLxc, "network", "delete", vm.Settings.Network.Name)
 
 		return errors.New("failed to attach network to profile: " + err.Error())
 	}

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -198,10 +198,10 @@ pools:
 - name: ` + vm.Settings.StoragePool.Name + "\n" +
 		`  driver: zfs
 networks:
-- name: ` + vm.Settings.Profile + "br0\n" +
+- name: ` + vm.Settings.Network.Name + "\n" +
 		`  type: bridge
   config:` + "\n" +
-		"    ipv4.address: " + vm.Settings.Network.Bridge + "/24 \n" +
+		"    ipv4.address: " + vm.Settings.Network.IP + "/24 \n" +
 		`    ipv4.nat: true
     ipv6.address: none
 profiles:
@@ -213,7 +213,7 @@ profiles:
 		`      type: disk
     eth0:
       nictype: bridged
-      parent: ` + vm.Settings.Profile + "br0\n" +
+      parent: ` + vm.Settings.Network.Name + "\n" +
 		`      type: nic
 EOF`
 

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -701,16 +701,6 @@ func DeleteUnit(lxdServer lxd.InstanceServer, name string) error {
 		return err
 	}
 
-	devices := []string{}
-	for key, value := range unit.Devices {
-		if value["type"] == "disk" {
-			devices = append(devices, key)
-		}
-	}
-	if len(devices) > 0 {
-		return errors.New("cannot delete unit " + name + " due to mounted disks. Umount them and try again")
-	}
-
 	if unit.Status == "Running" {
 
 		req := api.InstanceStatePut{

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -47,7 +47,7 @@ func NewBravehostRemote(settings HostSettings) Remote {
 		Protocol: protocol,
 		Public:   false,
 		Profile:  settings.Profile,
-		Network:  settings.Network.Bridge,
+		Network:  settings.Network.Name,
 		Storage:  settings.StoragePool.Name,
 	}
 }


### PR DESCRIPTION
This addresses the issues mentioned in https://github.com/bravetools/bravetools/issues/155.

I removed the check for devices on a unit before removing it - I think it should be fine without it.

Fix made to use network device name rather than the IP. I also updated the network bridge name selection logic to localize it to one place for clarity.