### PR TITLE
Remote postdeploy

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -345,6 +345,26 @@ func listHostImages(lxdServer lxd.ImageServer) ([]api.Image, error) {
 // 	return ifaces, nil
 // }
 
+// postdeploy copy files and run commands on running service
+func postdeploy(ctx context.Context, lxdServer lxd.InstanceServer, unitConfig *shared.Service) (err error) {
+
+	if unitConfig.Postdeploy.Copy != nil {
+		err = bravefileCopy(ctx, lxdServer, unitConfig.Postdeploy.Copy, unitConfig.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	if unitConfig.Postdeploy.Run != nil {
+		err = bravefileRun(ctx, lxdServer, unitConfig.Postdeploy.Run, unitConfig.Name)
+		if err != nil {
+			return errors.New(shared.Fatal("failed to execute command: " + err.Error()))
+		}
+	}
+
+	return nil
+}
+
 func bravefileCopy(ctx context.Context, lxdServer lxd.InstanceServer, copy []shared.CopyCommand, service string) error {
 	dir, _ := os.Getwd()
 	for _, c := range copy {

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"context"
 	"log"
 	"testing"
 
@@ -82,8 +81,6 @@ func Test_InitUnit(t *testing.T) {
 		t.Fatal("failed to create host: ", err.Error())
 	}
 
-	ctx := context.Background()
-
 	bravefile := *shared.NewBravefile()
 	bravefile.Base.Image = "alpine/edge/amd64"
 	bravefile.Base.Location = "public"
@@ -119,11 +116,6 @@ func Test_InitUnit(t *testing.T) {
 	err = host.InitUnit(host.Backend, &bravefile.PlatformService)
 	if err != nil {
 		t.Error("host.InitUnit: ", err)
-	}
-
-	err = host.Postdeploy(ctx, &bravefile.PlatformService)
-	if err != nil {
-		t.Error("host.Postdeploy: ", err)
 	}
 
 	err = host.DeleteLocalImage("alpine-test-1.0")

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -175,7 +175,7 @@ func Test_ListUnits(t *testing.T) {
 		t.Error("host.HostInfo: ", err)
 	}
 
-	err = host.ListUnits(host.Backend)
+	err = host.ListUnits(host.Backend, "")
 	if err != nil {
 		t.Error("host.ListLocalImages: ", err)
 	}

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -636,6 +636,9 @@ func Exec(ctx context.Context, lxdServer lxd.InstanceServer, name string, comman
 			return err
 		}
 		c, _, err := lxdServer.GetContainerState(name)
+		if err != nil {
+			return fmt.Errorf("failed to get container %q: %s", name, err.Error())
+		}
 		ip := c.Network["eth0"].Addresses[0].Address
 		isIP := isIPv4(ip)
 		if !isIP {


### PR DESCRIPTION
Fix postdeploy section of Bravefile when executed on remote servers and make function private.

Update tests to work.