### PR TITLE
Remote unit management

### DIFF
--- a/commands/start.go
+++ b/commands/start.go
@@ -20,7 +20,7 @@ func start(cmd *cobra.Command, args []string) {
 		log.Fatal("missing name - please provide unit name")
 	}
 
-	err := host.StartUnit(args[0], backend)
+	err := host.StartUnit(args[0])
 	if err != nil {
 		log.Fatal(err)
 		os.Exit(1)

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -21,7 +21,7 @@ func stop(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err := host.StopUnit(args[0], backend)
+	err := host.StopUnit(args[0])
 	if err != nil {
 		log.Fatal(err)
 		os.Exit(1)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -878,16 +878,27 @@ func (bh *BraveHost) PublishUnit(name string, backend Backend) error {
 }
 
 // StopUnit stops unit using name
-func (bh *BraveHost) StopUnit(name string, backend Backend) error {
-	info, err := backend.Info()
-	if err != nil {
-		return errors.New("Failed to get host info: " + err.Error())
-	}
-	if strings.ToLower(info.State) == "stopped" {
-		return errors.New("Backend is stopped")
+func (bh *BraveHost) StopUnit(name string) error {
+
+	remoteName, name := ParseRemoteName(name)
+
+	// If local remote, ensure the VM is started
+	if remoteName == shared.BravetoolsRemote {
+		info, err := bh.Backend.Info()
+		if err != nil {
+			return errors.New("Failed to get host info: " + err.Error())
+		}
+		if strings.ToLower(info.State) == "stopped" {
+			return errors.New("Backend is stopped")
+		}
 	}
 
-	lxdServer, err := GetLXDInstanceServer(bh.Remote)
+	remote, err := LoadRemoteSettings(remoteName)
+	if err != nil {
+		return err
+	}
+
+	lxdServer, err := GetLXDInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -304,7 +304,12 @@ func (bh *BraveHost) ListUnits(backend Backend, remoteName string) error {
 			return err
 		}
 
-		units, err = GetUnits(lxdServer, deployRemote.Profile)
+		deployProfile := deployRemote.Profile
+		if deployProfile == "" {
+			deployProfile = deployRemote.Profile
+		}
+
+		units, err = GetUnits(lxdServer, deployProfile)
 		if err != nil {
 			return errors.New("Failed to list units: " + err.Error())
 		}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -913,16 +913,26 @@ func (bh *BraveHost) StopUnit(name string) error {
 }
 
 // StartUnit restarts unit if running and starts if stopped.
-func (bh *BraveHost) StartUnit(name string, backend Backend) error {
-	info, err := backend.Info()
-	if err != nil {
-		return errors.New("Failed to get host info: " + err.Error())
-	}
-	if strings.ToLower(info.State) == "stopped" {
-		return errors.New("Backend is stopped")
+func (bh *BraveHost) StartUnit(name string) error {
+	remoteName, name := ParseRemoteName(name)
+
+	// If local remote, ensure the VM is started
+	if remoteName == shared.BravetoolsRemote {
+		info, err := bh.Backend.Info()
+		if err != nil {
+			return errors.New("Failed to get host info: " + err.Error())
+		}
+		if strings.ToLower(info.State) == "stopped" {
+			return errors.New("Backend is stopped")
+		}
 	}
 
-	lxdServer, err := GetLXDInstanceServer(bh.Remote)
+	remote, err := LoadRemoteSettings(remoteName)
+	if err != nil {
+		return err
+	}
+
+	lxdServer, err := GetLXDInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -128,7 +128,7 @@ func Test_InitUnit(t *testing.T) {
 		t.Error("host.StopUnit: ", err)
 	}
 
-	err = host.StartUnit("alpine-test", host.Backend)
+	err = host.StartUnit("alpine-test")
 	if err != nil {
 		t.Error("host.StartUnit: ", err)
 	}

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"context"
 	"log"
 	"testing"
 
@@ -82,8 +81,6 @@ func Test_InitUnit(t *testing.T) {
 		t.Fatal("failed to create host: ", err.Error())
 	}
 
-	ctx := context.Background()
-
 	bravefile := *shared.NewBravefile()
 	bravefile.Base.Image = "alpine/edge/amd64"
 	bravefile.Base.Location = "public"
@@ -121,17 +118,12 @@ func Test_InitUnit(t *testing.T) {
 		t.Error("host.InitUnit: ", err)
 	}
 
-	err = host.Postdeploy(ctx, &bravefile.PlatformService)
-	if err != nil {
-		t.Error("host.Postdeploy: ", err)
-	}
-
 	err = host.DeleteLocalImage("alpine-test-1.0")
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}
 
-	err = host.StopUnit("alpine-test", host.Backend)
+	err = host.StopUnit("alpine-test")
 	if err != nil {
 		t.Error("host.StopUnit: ", err)
 	}
@@ -175,7 +167,7 @@ func Test_ListUnits(t *testing.T) {
 		t.Error("host.HostInfo: ", err)
 	}
 
-	err = host.ListUnits(host.Backend)
+	err = host.ListUnits(host.Backend, "")
 	if err != nil {
 		t.Error("host.ListLocalImages: ", err)
 	}


### PR DESCRIPTION
This allows for management of remotely deployed units.

Remotely deployed units can now be:
- Started
- Stopped
- Deleted

In addition, the local bravetools backend VM (if on Windows/Mac) will only be started if the "local" remote is requested.

Fallback logic to filter listed units by bravetools host Profile if deploy Remote has no associated profile added.  