### PR TITLE
Terser local unit names

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -344,8 +344,10 @@ func (bh *BraveHost) ListUnits(backend Backend, remoteName string) error {
 			}
 
 			// Prefix unit name with remote name
-			for j := range remoteUnits {
-				remoteUnits[j].Name = deployRemote.Name + ":" + remoteUnits[j].Name
+			if deployRemote.Name != shared.BravetoolsRemote {
+				for j := range remoteUnits {
+					remoteUnits[j].Name = deployRemote.Name + ":" + remoteUnits[j].Name
+				}
 			}
 			units = append(units, remoteUnits...)
 		}


### PR DESCRIPTION
When running `brave units`, only prefix remote name if it is not the local bravetools remote. If no remote is listed, the "local" remote can be assumed.

This makes output cleaner when only local units are involved. In the case of multiple remotes the units will still be grouped together by remote so there shouldn't be a loss of clarity.