### PR TITLE
Image name schema

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -671,7 +671,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 		imageStruct.Version = bravefile.PlatformService.Version
 	}
 	if imageExists(imageStruct) {
-		return &ImageExistsError{Name: bravefile.PlatformService.Image}
+		return &ImageExistsError{Name: imageStruct.String()}
 	}
 
 	// Intercept SIGINT, propagate cancel and cleanup artefacts
@@ -746,7 +746,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			return err
 		}
 		if !imageExists(localBaseImage) {
-			return fmt.Errorf("base image %q required for building image %q does not exist", bravefile.Base.Image, bravefile.PlatformService.Image)
+			return fmt.Errorf("base image %q required for building image %q does not exist", localBaseImage.String(), imageStruct.String())
 		}
 
 		imgSize, err := localImageSize(localBaseImage)
@@ -1052,7 +1052,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 		imageStruct.Version = unitParams.Version
 	}
 	if !imageExists(imageStruct) {
-		return fmt.Errorf("image %q does not exist", unitParams.Image)
+		return fmt.Errorf("image %q does not exist", imageStruct.String())
 	}
 
 	image := path.Join(homeDir, shared.ImageStore, imageStruct.ToBasename()+".tar.gz")

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -666,6 +666,10 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 	if err != nil {
 		return err
 	}
+	// If version explicitly provided separately that overrides version specified in image field
+	if bravefile.PlatformService.Version != "" {
+		imageStruct.Version = bravefile.PlatformService.Version
+	}
 	if imageExists(imageStruct) {
 		return &ImageExistsError{Name: bravefile.PlatformService.Image}
 	}
@@ -1043,6 +1047,9 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 	imageStruct, err := ParseImageString(unitParams.Image)
 	if err != nil {
 		return err
+	}
+	if unitParams.Version != "" {
+		imageStruct.Version = unitParams.Version
 	}
 	if !imageExists(imageStruct) {
 		return fmt.Errorf("image %q does not exist", unitParams.Image)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -138,16 +138,19 @@ func (bh *BraveHost) ListLocalImages() error {
 
 	if len(images) > 0 {
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"Image", "Created", "Size", "Hash"})
+		table.SetHeader([]string{"Image", "Version", "Arch", "Created", "Size", "Hash"})
 
 		for _, i := range images {
+			image, err := ImageFromFilename(filepath.Base(i))
+			if err != nil {
+				return fmt.Errorf("failed to parse image filename schema from %q", i)
+			}
+
 			fi, err := os.Stat(i)
 			if strings.Index(fi.Name(), ".") != 0 {
 				if err != nil {
 					return errors.New("failed to get image size: " + err.Error())
 				}
-
-				name := strings.Split(fi.Name(), ".tar.gz")[0]
 
 				size := fi.Size()
 
@@ -196,7 +199,7 @@ func (bh *BraveHost) ListLocalImages() error {
 				hashString := string(hash)
 				hashString = strings.TrimRight(hashString, "\r\n")
 
-				r := []string{name, timeUnit, shared.FormatByteCountSI(size), hashString}
+				r := []string{image.Name, image.Version, image.Architecture, timeUnit, shared.FormatByteCountSI(size), hashString}
 				table.Append(r)
 			}
 		}

--- a/platform/images.go
+++ b/platform/images.go
@@ -1,0 +1,133 @@
+package platform
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/bravetools/bravetools/shared"
+)
+
+const defaultImageVersion = "1.0"
+
+type BravetoolsImage struct {
+	Name         string
+	Version      string
+	Architecture string
+}
+
+func ParseImageString(imageString string) (imageStruct BravetoolsImage, err error) {
+	// Remove remote if present
+	_, imageString = ParseRemoteName(imageString)
+
+	// Image schema: image/version/arch
+	split := strings.SplitN(imageString, "/", 4)
+
+	if len(split) > 4 {
+		return imageStruct, fmt.Errorf("unrecongized format - bravetools image schema is remote:<image_name>[/version/arch]")
+	}
+
+	if split[0] == "" {
+		return imageStruct, fmt.Errorf("image name not provided in %q - bravetools image schema is remote:<image_name>[/version/arch]", imageString)
+	}
+
+	// Default struct
+	// Architecture defaults to runtime arch
+	// Version defaults to 1.0
+	imageStruct = BravetoolsImage{
+		Name:         split[0],
+		Version:      defaultImageVersion,
+		Architecture: runtime.GOARCH,
+	}
+
+	// Override defaults if provided
+	if len(split) >= 3 {
+		imageStruct.Architecture = split[2]
+	}
+
+	if len(split) >= 2 {
+		imageStruct.Version = split[1]
+	}
+
+	return imageStruct, nil
+}
+
+func (imageStruct BravetoolsImage) ToBasename() string {
+	fields := []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture}
+	return strings.Join(fields, "_")
+}
+
+func ImageFromFilename(filename string) (BravetoolsImage, error) {
+	filename = strings.TrimSuffix(filename, ".tar.gz")
+	split := strings.Split(filename, "_")
+	if len(split) > 3 {
+		return BravetoolsImage{}, fmt.Errorf("filename %q does not conform to image format '<image_name>_<version>_<arch>", filename)
+	}
+
+	image := BravetoolsImage{
+		Name:         split[0],
+		Version:      defaultImageVersion,
+		Architecture: runtime.GOARCH,
+	}
+
+	if len(split) > 1 {
+		image.Version = split[1]
+	}
+	if len(split) > 2 {
+		image.Architecture = split[2]
+	}
+
+	return image, nil
+}
+
+func imageExists(image BravetoolsImage) bool {
+	homeDir, _ := os.UserHomeDir()
+	imagePath := path.Join(homeDir, shared.ImageStore, image.ToBasename()+".tar.gz")
+	return shared.FileExists(imagePath)
+}
+
+func localImageSize(image BravetoolsImage) (bytes int64, err error) {
+	homeDir, _ := os.UserHomeDir()
+	imagePath := path.Join(homeDir, shared.ImageStore, image.ToBasename()+".tar.gz")
+
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		return -1, err
+	}
+	if info.IsDir() {
+		return -1, fmt.Errorf("expected image path %q to be a file, found dir", imagePath)
+	}
+
+	return info.Size(), nil
+}
+
+func resolveBaseImageLocation(imageString string) (location string, err error) {
+
+	remote, imageString := ParseRemoteName(imageString)
+
+	if remote == "github.com" {
+		return "github", nil
+	}
+
+	imageStruct, err := ParseImageString(imageString)
+	if err != nil {
+		return "", err
+	}
+
+	if imageExists(imageStruct) {
+		return "local", nil
+	}
+
+	// Query public remote for alias
+	publicLxd, err := GetSimplestreamsLXDSever("https://images.linuxcontainers.org", nil)
+	if err != nil {
+		return "", err
+	}
+	if _, err := GetFingerprintByAlias(publicLxd, imageString); err == nil {
+		return "public", nil
+	}
+
+	return "", fmt.Errorf("image %q location could not be resolved", imageString)
+}

--- a/platform/images.go
+++ b/platform/images.go
@@ -59,6 +59,11 @@ func (imageStruct BravetoolsImage) ToBasename() string {
 	return strings.Join(fields, "_")
 }
 
+func (imageStruct BravetoolsImage) String() string {
+	fields := []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture}
+	return strings.Join(fields, "/")
+}
+
 func ImageFromFilename(filename string) (BravetoolsImage, error) {
 	filename = strings.TrimSuffix(filename, ".tar.gz")
 	split := strings.Split(filename, "_")

--- a/platform/images_test.go
+++ b/platform/images_test.go
@@ -1,0 +1,89 @@
+package platform
+
+import "testing"
+
+func TestParseImageString(t *testing.T) {
+	name := "local:alpine/3.16/amd64"
+	image, err := ParseImageString(name)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	t.Logf("%+v", image)
+}
+
+func TestParseImageStringDefaultArch(t *testing.T) {
+	name := "local:alpine/3.16"
+	image, err := ParseImageString(name)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	t.Logf("%+v", image)
+}
+
+func TestParseImageStringDefaultVersion(t *testing.T) {
+	name := "local:alpine"
+	image, err := ParseImageString(name)
+	if err != nil {
+		t.Fatalf("expected err when parsing image from filename %q", name)
+	}
+	t.Logf("%+v", image)
+}
+
+func TestParseImageStringNoName(t *testing.T) {
+	name := "local:"
+	_, err := ParseImageString(name)
+	if err == nil {
+		t.Fatalf("expected err when parsing image from filename %q", name)
+	}
+}
+
+func TestImageFromFilename(t *testing.T) {
+	name := "alpine_3.16_amd64.tar.gz"
+	image, err := ImageFromFilename(name)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	t.Logf("%+v", image)
+}
+
+func TestImageFromFilenameLong(t *testing.T) {
+	name := "alpine_3.16_amd64_test.tar.gz"
+	_, err := ImageFromFilename(name)
+	if err == nil {
+		t.Fatalf("expected err when parsing image from filename %q", name)
+	}
+}
+
+func TestImageFromFilenameShort(t *testing.T) {
+	name := "alpine_3.16_amd64_test.tar.gz"
+	_, err := ImageFromFilename(name)
+	if err == nil {
+		t.Fatalf("expected err when parsing image from filename %q", name)
+	}
+}
+
+func TestImageFromFilenameReal(t *testing.T) {
+	name := "python-auth-1.0_1.0_amd64.tar.gz"
+	image, err := ImageFromFilename(name)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	t.Logf("%+v", image)
+}
+
+func TestImageFromFilenameLegacy(t *testing.T) {
+	name := "python-api-1.0.tar.gz"
+	image, err := ImageFromFilename(name)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	t.Logf("%+v", image)
+}
+
+func TestImageFromFilenameIncorrectLong(t *testing.T) {
+	name := "python-auth-1.0_1.0_amd64_TEST.tar.gz"
+	_, err := ImageFromFilename(name)
+	if err == nil {
+		t.Fatalf("expected err when parsing image from filename %q", name)
+	}
+}

--- a/platform/resources.go
+++ b/platform/resources.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CheckResources ..
-func CheckResources(image string, backend Backend, unitParams *shared.Service, bh *BraveHost) error {
+func CheckResources(image BravetoolsImage, backend Backend, unitParams *shared.Service, bh *BraveHost) error {
 	info, err := backend.Info()
 	if err != nil {
 		return errors.New("failed to connect to host: " + err.Error())

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -13,8 +14,9 @@ import (
 
 // ImageDescription defines base image type and source
 type ImageDescription struct {
-	Image    string `yaml:"image"`
-	Location string `yaml:"location"`
+	Image        string `yaml:"image"`
+	Location     string `yaml:"location"`
+	Architecture string `yaml:architecture`
 }
 
 // Packages defines system packages to install in container
@@ -78,6 +80,9 @@ type Bravefile struct {
 // NewBravefile ..
 func NewBravefile() *Bravefile {
 	return &Bravefile{
+		Base: ImageDescription{
+			Architecture: runtime.GOARCH,
+		},
 		PlatformService: Service{
 			Resources: Resources{
 				CPU: DefaultUnitCpuLimit,


### PR DESCRIPTION
Implements the approach to image naming schema mentioned here in https://github.com/bravetools/bravetools/issues/140.
Also addresses issue https://github.com/bravetools/bravetools/issues/152 regarding storing image architecture.

## Image naming schema
Using this new image naming schema, the user can optionally provide the image version and architecture as part of the image field by using slashes as delimiters.

The schema is as mentioned in the issue above except the remote prefix is not yet implemented:
`name[/version][/arch]`

If version is not provided, it defaults to "1.0". Arch will default to the bravetools runtime architecture if not specified - in future it would be best to infer arch based on architecture of LXD build server/deploy server by querying the LXD server.

If the user seperately provides a value for the Service.Version field, that overrides the version in the image field. Thanks to this, this change is backwards compatible - old Bravefiles that specify version with the field will continue to work.

## Image file metadata (architecture and version)
The image files on disk now also contain architecture information, for example:
`python-auth_1.0_amd64.tar.gz`

The metadata fields are delimited by `_` and are in the same order as above:
`name[_version][_arch].tar.gz`

This change is backwards compatible in a sense, although the new metadata fields will be set to defaults as above if they are missing. For example:
`python-api-1.0.tar.gz` will be read as 
```
IMAGE                           VERSION ARCH
python-api-1.0                  1.0     amd64
```

This metadata (version and arch) is read and presented when running `brave images`.
```
brave images

IMAGE                       VERSION ARCH    CREATED         SIZE    HASH
python-api                  1.0     amd64   2 days ago      28MB    7cd1b20142480707b1fb2dbbaa4c1000
python-auth                 1.0     amd64   just now        28MB    5f9e37a9eadb98cefb16d706572e0054
python-auth                 2.0     amd64   just now        28MB    4c6553c35bd9de678ead8c2bd5cf4da9
```