### PR TITLE
Backwards compatability with image fields in existing Bravefiles

### DIFF
--- a/platform/images.go
+++ b/platform/images.go
@@ -1,11 +1,14 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
 	"strings"
+	"unicode"
 
 	"github.com/bravetools/bravetools/shared"
 )
@@ -35,7 +38,6 @@ func ParseImageString(imageString string) (imageStruct BravetoolsImage, err erro
 
 	// Default struct
 	// Architecture defaults to runtime arch
-	// Version defaults to 1.0
 	imageStruct = BravetoolsImage{
 		Name:         split[0],
 		Version:      defaultImageVersion,
@@ -51,7 +53,61 @@ func ParseImageString(imageString string) (imageStruct BravetoolsImage, err erro
 		imageStruct.Version = split[1]
 	}
 
+	if !validImageName(imageStruct) {
+		return imageStruct, fmt.Errorf("image %q is not a valid string - fields must not contain special characters", imageString)
+	}
+
 	return imageStruct, nil
+}
+
+func ParseLegacyImageString(imageString string) (imageStruct BravetoolsImage, err error) {
+	// Legacy Bravefile - these have the version prepended to end of name and no arch
+	split := strings.Split(imageString, "-")
+	if len(split) == 1 {
+		return imageStruct, fmt.Errorf("failed to parse legacy Bravefile image field %q - expected %q at end", imageString, "-[version]")
+	}
+
+	// Default struct
+	// Architecture defaults to runtime arch
+	imageStruct = BravetoolsImage{
+		Name:         strings.Join(split[:len(split)-1], "-"),
+		Version:      split[len(split)-1],
+		Architecture: runtime.GOARCH,
+	}
+
+	if !validImageName(imageStruct) {
+		return imageStruct, fmt.Errorf("image %q is not a valid string - fields must not contain special characters", imageString)
+	}
+
+	return imageStruct, nil
+}
+func validImageName(imageStruct BravetoolsImage) bool {
+	// Check Name, Version and Architecture fields for non-allowed characters
+	for _, char := range imageStruct.Name {
+		if !validImageFieldChar(char) {
+			return false
+		}
+	}
+	for _, char := range imageStruct.Version {
+		if !validImageFieldChar(char) {
+			return false
+		}
+	}
+	for _, char := range imageStruct.Architecture {
+		if !validImageFieldChar(char) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validImageFieldChar(char rune) bool {
+	// Alpha-numeric is fine, along with '-' and '.
+	if !unicode.IsLetter(char) && !unicode.IsNumber(char) && char != '-' && char != '.' {
+		return false
+	}
+	return true
 }
 
 func (imageStruct BravetoolsImage) ToBasename() string {
@@ -84,18 +140,82 @@ func ImageFromFilename(filename string) (BravetoolsImage, error) {
 		image.Architecture = split[2]
 	}
 
+	// Legacy filenames are not delimited by underscores
+	// Final "-" is followed by version - no arch
+	if len(split) == 1 {
+		split = strings.Split(filename, "-")
+		image.Name = strings.Join(split[:len(split)-1], "-")
+		image.Version = split[len(split)-1]
+	}
+
 	return image, nil
 }
 
 func imageExists(image BravetoolsImage) bool {
+	_, err := getImageFilepath(image)
+	return err == nil
+}
+
+func getImageFilepath(image BravetoolsImage) (string, error) {
 	homeDir, _ := os.UserHomeDir()
 	imagePath := path.Join(homeDir, shared.ImageStore, image.ToBasename()+".tar.gz")
-	return shared.FileExists(imagePath)
+	if shared.FileExists(imagePath) {
+		return imagePath, nil
+	}
+	// Legacy filenames will not have arch
+	imagePath = path.Join(homeDir, shared.ImageStore, image.Name+"-"+image.Version+".tar.gz")
+	if shared.FileExists(imagePath) {
+		return imagePath, nil
+	}
+	return "", fmt.Errorf("failed to retrieve path for image %s, version %s, arch %s ", image.Name, image.Version, image.Architecture)
+}
+
+func getImageHash(image BravetoolsImage) (string, error) {
+	localImageFile, err := getImageFilepath(image)
+	if err != nil {
+		return "", err
+	}
+	hashFileName := localImageFile + ".md5"
+
+	hash, err := ioutil.ReadFile(hashFileName)
+	if err != nil {
+		if os.IsNotExist(err) {
+
+			imageHash, err := shared.FileHash(localImageFile)
+			if err != nil {
+				return "", errors.New("failed to generate image hash: " + err.Error())
+			}
+
+			f, err := os.Create(hashFileName)
+			if err != nil {
+				return "", errors.New(err.Error())
+			}
+			defer f.Close()
+
+			_, err = f.WriteString(imageHash)
+			if err != nil {
+				return "", errors.New(err.Error())
+			}
+
+			hash, err = ioutil.ReadFile(hashFileName)
+			if err != nil {
+				return "", errors.New(err.Error())
+			}
+		} else {
+			return "", errors.New("couldn't load image hash: " + err.Error())
+		}
+	}
+
+	hashString := string(hash)
+	hashString = strings.TrimRight(hashString, "\r\n")
+	return hashString, nil
 }
 
 func localImageSize(image BravetoolsImage) (bytes int64, err error) {
-	homeDir, _ := os.UserHomeDir()
-	imagePath := path.Join(homeDir, shared.ImageStore, image.ToBasename()+".tar.gz")
+	imagePath, err := getImageFilepath(image)
+	if err != nil {
+		return bytes, err
+	}
 
 	info, err := os.Stat(imagePath)
 	if err != nil {
@@ -121,6 +241,15 @@ func resolveBaseImageLocation(imageString string) (location string, err error) {
 		return "", err
 	}
 
+	if imageExists(imageStruct) {
+		return "local", nil
+	}
+
+	// Check for legacy image field
+	imageStruct, err = ParseLegacyImageString(imageString)
+	if err != nil {
+		return "", err
+	}
 	if imageExists(imageStruct) {
 		return "local", nil
 	}

--- a/platform/images_test.go
+++ b/platform/images_test.go
@@ -37,6 +37,15 @@ func TestParseImageStringNoName(t *testing.T) {
 	}
 }
 
+func TestParseImageStringLegacy(t *testing.T) {
+	name := "alpine-3.16"
+	image, err := ParseLegacyImageString(name)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	t.Logf("%+v", image)
+}
+
 func TestImageFromFilename(t *testing.T) {
 	name := "alpine_3.16_amd64.tar.gz"
 	image, err := ImageFromFilename(name)


### PR DESCRIPTION
Old image name schema prepended `-<version>` to the end of the image name. The new format specifies the version within the image name itself like so: `<image_name>/<version>`.

Existing Bravefiles do not work nicely with the new image name parsing - this PR adds the logic for dealing with the old image format (both Bravefiles and image files). Legacy image name parsing will be enabled when version field is passed a value in the Bravefile - suggested that new Bravefiles omit the field in favour of the new syntax.

CLI commands and Base images check both the new parsing and legacy parsing methods so existing image names can be manipulated using their names as specified in existing Bravefiles - this makes it possible to remove images by their legacy names, for example.