### PR TITLE
Brave build refactor

### DIFF
--- a/commands/base.go
+++ b/commands/base.go
@@ -40,7 +40,7 @@ func buildBase(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err = host.BuildImage(bravefile)
+	err = host.BuildImage(*bravefile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/commands/base.go
+++ b/commands/base.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/bravetools/bravetools/platform"
 	"github.com/bravetools/bravetools/shared"
 
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func buildBase(cmd *cobra.Command, args []string) {
 		}
 
 	} else {
-		bravefile, err = shared.GetBravefileFromLXD(args[0])
+		bravefile, err = platform.GetBravefileFromLXD(args[0])
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/commands/build.go
+++ b/commands/build.go
@@ -40,7 +40,7 @@ func build(cmd *cobra.Command, args []string) {
 		log.Fatal("Failed to load Bravefile: ", err)
 	}
 
-	err = host.BuildImage(bravefile)
+	err = host.BuildImage(*bravefile)
 	switch errType := err.(type) {
 	case nil:
 	case *platform.ImageExistsError:

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -75,6 +75,11 @@ func deploy(cmd *cobra.Command, args []string) {
 	deployArgs.Merge(&bravefile.PlatformService)
 	bravefile.PlatformService = *deployArgs
 
+	// If Service section does not define an Image, use the Build-section Image field
+	if bravefile.PlatformService.Image == "" {
+		bravefile.PlatformService.Image = bravefile.Image
+	}
+
 	err = host.InitUnit(backend, &bravefile.PlatformService)
 	if err != nil {
 		log.Fatal(err)

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -80,7 +80,7 @@ func deploy(cmd *cobra.Command, args []string) {
 		bravefile.PlatformService.Image = bravefile.Image
 	}
 
-	err = host.InitUnit(backend, &bravefile.PlatformService)
+	err = host.InitUnit(backend, bravefile.PlatformService)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -166,8 +166,6 @@ func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *
 	if err != nil {
 		return fingerprint, err
 	}
-	// Ensure that the up-to-date "version" value is in the Bravefile for later use
-	remoteBravefile.PlatformService.Version = imageStruct.Version
 
 	if !imageExists(imageStruct) {
 		err = bh.BuildImage(remoteBravefile)
@@ -202,8 +200,6 @@ func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *s
 	if err != nil {
 		return "", err
 	}
-	// Ensure that the up-to-date "version" value is in the Bravefile for later use
-	bravefile.PlatformService.Version = imageStruct.Version
 
 	path, err := getImageFilepath(imageStruct)
 	if err != nil {

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -168,7 +168,7 @@ func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *
 	}
 
 	if !imageExists(imageStruct) {
-		err = bh.BuildImage(remoteBravefile)
+		err = bh.BuildImage(*remoteBravefile)
 		if err != nil {
 			return fingerprint, err
 		}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1010,6 +1010,9 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 	if unitParams.Image == "" {
 		return errors.New("unit image name cannot be empty")
 	}
+	if strings.ContainsAny(unitParams.Name, "/_. !@£$%^&*(){}:;`~,?") {
+		return errors.New("unit names should not contain special characters")
+	}
 
 	fmt.Println(shared.Info("Deploying Unit " + unitParams.Name))
 

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -662,13 +662,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 
 	fmt.Println(shared.Info("Building Image: " + imageStruct.String()))
 
-	if strings.ContainsAny(bravefile.PlatformService.Name, "/_. !@£$%^&*(){}:;`~,?") {
-		return errors.New("unit names should not contain special characters")
-	}
-
-	if bravefile.PlatformService.Name == "" {
-		return errors.New("service Name is empty")
-	}
+	bravefile.PlatformService.Name = "brave-build-" + strings.ReplaceAll(strings.ReplaceAll(imageStruct.ToBasename(), "_", "-"), ".", "-")
 
 	lxdServer, err := GetLXDInstanceServer(bh.Remote)
 	if err != nil {

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1027,8 +1027,6 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 	if err != nil {
 		return err
 	}
-	// Ensure that the up-to-date "version" value is in the Bravefile for later use
-	unitParams.Version = imageStruct.Version
 
 	if !imageExists(imageStruct) {
 		return fmt.Errorf("image %q does not exist", imageStruct.String())

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -649,8 +649,6 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 	if err != nil {
 		return err
 	}
-	// Ensure that the up-to-date "version" value is in the Bravefile for later use
-	bravefile.PlatformService.Version = imageStruct.Version
 
 	if imageExists(imageStruct) {
 		return &ImageExistsError{Name: imageStruct.String()}
@@ -840,7 +838,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 	}
 
 	// Create an image based on running container and export it. Image saved as tar.gz in project local directory.
-	unitFingerprint, err := Publish(lxdServer, bravefile.PlatformService.Name, bravefile.PlatformService.Version)
+	unitFingerprint, err := Publish(lxdServer, bravefile.PlatformService.Name, imageStruct.String())
 	defer DeleteImageByFingerprint(lxdServer, unitFingerprint)
 	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("failed to publish image: " + err.Error())

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -635,7 +635,7 @@ func (e *ImageExistsError) Error() string {
 }
 
 // BuildImage creates an image based on Bravefile
-func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
+func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 
 	var imageStruct BravetoolsImage
 	var err error
@@ -720,7 +720,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			return err
 		}
 
-		imageFingerprint, err = importLXD(ctx, lxdServer, bravefile, bh.Remote.Profile)
+		imageFingerprint, err = importLXD(ctx, lxdServer, &bravefile, bh.Remote.Profile)
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return err
 		}
@@ -730,7 +730,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			return err
 		}
 	case "github":
-		imageFingerprint, err = importGitHub(ctx, lxdServer, bravefile, bh, bh.Remote.Profile, bh.Remote.Storage)
+		imageFingerprint, err = importGitHub(ctx, lxdServer, &bravefile, bh, bh.Remote.Profile, bh.Remote.Storage)
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return err
 		}
@@ -765,7 +765,7 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 			return err
 		}
 
-		imageFingerprint, err = importLocal(ctx, lxdServer, bravefile, bh.Remote.Profile, bh.Remote.Storage)
+		imageFingerprint, err = importLocal(ctx, lxdServer, &bravefile, bh.Remote.Profile, bh.Remote.Storage)
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return err
 		}
@@ -1002,7 +1002,7 @@ func (bh *BraveHost) StartUnit(name string) error {
 }
 
 // InitUnit starts unit from supplied image
-func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err error) {
+func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err error) {
 	// Check for missing mandatory fields
 	if unitParams.Name == "" {
 		return errors.New("unit name cannot be empty")
@@ -1082,7 +1082,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 
 	// Resource checks
 	// TODO: this should use a profile
-	err = CheckResources(imageStruct, backend, unitParams, bh)
+	err = CheckResources(imageStruct, backend, &unitParams, bh)
 	if err != nil {
 		return err
 	}
@@ -1228,7 +1228,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams *shared.Service) (err 
 		}
 	}
 
-	err = postdeploy(ctx, lxdServer, unitParams)
+	err = postdeploy(ctx, lxdServer, &unitParams)
 	if err = shared.CollectErrors(err, ctx.Err()); err != nil {
 		return err
 	}
@@ -1330,7 +1330,7 @@ func (bh *BraveHost) Compose(backend Backend, composeFile *shared.ComposeFile) (
 				}
 				os.Chdir(buildDir)
 
-				err = bh.BuildImage(service.BravefileBuild)
+				err = bh.BuildImage(*service.BravefileBuild)
 				switch errType := err.(type) {
 				case nil:
 					// Cleanup image later if error in compose
@@ -1375,7 +1375,7 @@ func (bh *BraveHost) Compose(backend Backend, composeFile *shared.ComposeFile) (
 			os.Chdir(deployDir)
 
 			// Cleanup each unit if error in compose
-			err = bh.InitUnit(backend, &service.Service)
+			err = bh.InitUnit(backend, service.Service)
 			if err != nil {
 				return err
 			}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -640,11 +640,17 @@ func (bh *BraveHost) BuildImage(bravefile *shared.Bravefile) error {
 	var imageStruct BravetoolsImage
 	var err error
 
+	// The image to build - if not in build section, use Image defined in Service section
+	imageString := bravefile.Image
+	if imageString == "" {
+		imageString = bravefile.PlatformService.Image
+	}
+
 	// If version explicitly provided separately this is a legacy Bravefile
-	if bravefile.PlatformService.Version == "" {
-		imageStruct, err = ParseImageString(bravefile.PlatformService.Image)
+	if bravefile.PlatformService.Version == "" || bravefile.Image != "" {
+		imageStruct, err = ParseImageString(imageString)
 	} else {
-		imageStruct, err = ParseLegacyImageString(bravefile.PlatformService.Image)
+		imageStruct, err = ParseLegacyImageString(imageString)
 	}
 	if err != nil {
 		return err

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -190,6 +190,12 @@ func Test_Compose(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Composefile specifies static IP addresses for containers, test will fail on bravetools setups where LXD bridge is on different IP range
+	// For this test, will just clear static IP addresses
+	for _, service := range composefile.Services {
+		service.IP = ""
+	}
+
 	err = host.Compose(host.Backend, composefile)
 	if err != nil {
 		t.Error("host.BuildImage: ", err)

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -13,9 +13,9 @@ func Test_DeleteLocalImage(t *testing.T) {
 		t.Fatal("failed to create host: ", err.Error())
 	}
 
-	bravefile, err := shared.GetBravefileFromLXD("alpine/edge/amd64")
+	bravefile, err := GetBravefileFromLXD("alpine/edge/amd64")
 	if err != nil {
-		t.Error("shared.GetBravefileFromLXD: ", err)
+		t.Error("platform.GetBravefileFromLXD: ", err)
 	}
 
 	err = host.BuildImage(bravefile)
@@ -23,7 +23,7 @@ func Test_DeleteLocalImage(t *testing.T) {
 		t.Error("host.BuildImage: ", err)
 	}
 
-	err = host.DeleteLocalImage("brave-base-alpine-edge-1.0")
+	err = host.DeleteLocalImage("alpine/edge/amd64")
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -121,22 +121,22 @@ func Test_InitUnit(t *testing.T) {
 		t.Error("host.InitUnit: ", err)
 	}
 
-	err = host.DeleteLocalImage("alpine-test-1.0")
+	err = host.DeleteLocalImage(bravefile.PlatformService.Image)
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}
 
-	err = host.StopUnit("alpine-test")
+	err = host.StopUnit(bravefile.PlatformService.Name)
 	if err != nil {
 		t.Error("host.StopUnit: ", err)
 	}
 
-	err = host.StartUnit("alpine-test")
+	err = host.StartUnit(bravefile.PlatformService.Name)
 	if err != nil {
 		t.Error("host.StartUnit: ", err)
 	}
 
-	err = host.DeleteUnit("alpine-test")
+	err = host.DeleteUnit(bravefile.PlatformService.Name)
 	if err != nil {
 		t.Error("host.DeleteUnit: ", err)
 	}

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -13,7 +13,9 @@ func Test_DeleteLocalImage(t *testing.T) {
 		t.Fatal("failed to create host: ", err.Error())
 	}
 
-	bravefile, err := GetBravefileFromLXD("alpine/edge/amd64")
+	imageName := "alpine/edge/amd64"
+
+	bravefile, err := GetBravefileFromLXD(imageName)
 	if err != nil {
 		t.Error("platform.GetBravefileFromLXD: ", err)
 	}
@@ -23,7 +25,7 @@ func Test_DeleteLocalImage(t *testing.T) {
 		t.Error("host.BuildImage: ", err)
 	}
 
-	err = host.DeleteLocalImage("alpine/edge/amd64")
+	err = host.DeleteLocalImage(imageName)
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}
@@ -62,6 +64,7 @@ func Test_BuildImage(t *testing.T) {
 	bravefile.Run = []shared.RunCommand{*runCommand}
 
 	bravefile.PlatformService.Name = "alpine-test"
+	bravefile.PlatformService.Image = "alpine-test-1.0"
 	bravefile.PlatformService.Version = "1.0"
 
 	err = host.BuildImage(&bravefile)
@@ -69,7 +72,7 @@ func Test_BuildImage(t *testing.T) {
 		t.Error("host.BuildImage: ", err)
 	}
 
-	err = host.DeleteLocalImage("alpine-test-1.0")
+	err = host.DeleteLocalImage(bravefile.PlatformService.Image)
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -20,7 +20,7 @@ func Test_DeleteLocalImage(t *testing.T) {
 		t.Error("platform.GetBravefileFromLXD: ", err)
 	}
 
-	err = host.BuildImage(bravefile)
+	err = host.BuildImage(*bravefile)
 	if err != nil {
 		t.Error("host.BuildImage: ", err)
 	}
@@ -67,7 +67,7 @@ func Test_BuildImage(t *testing.T) {
 	bravefile.PlatformService.Image = "alpine-test-1.0"
 	bravefile.PlatformService.Version = "1.0"
 
-	err = host.BuildImage(&bravefile)
+	err = host.BuildImage(bravefile)
 	if err != nil {
 		t.Error("host.BuildImage: ", err)
 	}
@@ -111,7 +111,7 @@ func Test_InitUnit(t *testing.T) {
 		},
 	}
 
-	err = host.BuildImage(&bravefile)
+	err = host.BuildImage(bravefile)
 	if err != nil {
 		t.Error("host.BuildImage: ", err)
 	}

--- a/platform/images.go
+++ b/platform/images.go
@@ -265,3 +265,21 @@ func resolveBaseImageLocation(imageString string) (location string, err error) {
 
 	return "", fmt.Errorf("image %q location could not be resolved", imageString)
 }
+
+// GetBravefileFromLXD generates a Bravefile for import of images from LXD repository
+func GetBravefileFromLXD(name string) (*shared.Bravefile, error) {
+	bravefile := shared.NewBravefile()
+
+	image, err := ParseImageString(name)
+	if err != nil {
+		return nil, err
+	}
+
+	bravefile.Base.Image = image.String()
+	bravefile.Base.Location = "public"
+
+	bravefile.PlatformService.Name = "brave-base"
+	bravefile.PlatformService.Image = image.String()
+
+	return bravefile, nil
+}

--- a/platform/images.go
+++ b/platform/images.go
@@ -67,6 +67,10 @@ func ParseLegacyImageString(imageString string) (imageStruct BravetoolsImage, er
 		return imageStruct, fmt.Errorf("failed to parse legacy Bravefile image field %q - expected %q at end", imageString, "-[version]")
 	}
 
+	if split[0] == "" {
+		return imageStruct, fmt.Errorf("image name not provided in %q. Legacy Bravefiles image name format is [name]-[version]", imageString)
+	}
+
 	// Default struct
 	// Architecture defaults to runtime arch
 	imageStruct = BravetoolsImage{

--- a/platform/images.go
+++ b/platform/images.go
@@ -282,7 +282,7 @@ func GetBravefileFromLXD(name string) (*shared.Bravefile, error) {
 	bravefile.Base.Image = image.String()
 	bravefile.Base.Location = "public"
 
-	bravefile.PlatformService.Name = "brave-base"
+	bravefile.PlatformService.Name = ""
 	bravefile.PlatformService.Image = image.String()
 
 	return bravefile, nil

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -15,7 +15,7 @@ import (
 type ImageDescription struct {
 	Image        string `yaml:"image"`
 	Location     string `yaml:"location"`
-	Architecture string `yaml:architecture`
+	Architecture string `yaml:"architecture"`
 }
 
 // Packages defines system packages to install in container

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -69,7 +69,8 @@ type Resources struct {
 
 // Bravefile describes unit configuration
 type Bravefile struct {
-	Base            ImageDescription `yaml:"base"`
+	Image           string           `yaml:"image,omitempty"`
+	Base            ImageDescription `yaml:"base,omitempty"`
 	SystemPackages  Packages         `yaml:"packages,omitempty"`
 	Run             []RunCommand     `yaml:"run,omitempty"`
 	Copy            []CopyCommand    `yaml:"copy,omitempty"`

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"runtime"
 	"strings"
 
@@ -202,42 +201,6 @@ func GetBravefileFromGitHub(name string) (*Bravefile, error) {
 	}
 
 	err = yaml.Unmarshal([]byte(baseConfig), &bravefile)
-	if err != nil {
-		return nil, err
-	}
-
-	return &bravefile, nil
-}
-
-// GetBravefileFromLXD generates a Bravefile for import of images from LXD repository
-func GetBravefileFromLXD(name string) (*Bravefile, error) {
-	var bravefile Bravefile
-	var baseConfig string
-
-	dist := strings.SplitN(name, "/", -1)
-
-	if len(dist) == 1 {
-		return nil, errors.New("brave base accepts image names in the format NAME/VERSION/ARCH. See https://images.linuxcontainers.org for a list of supported images")
-	}
-
-	version := strings.SplitN(dist[1], ".", 2)
-	distroVersion := version[0]
-
-	if len(version) > 1 {
-		distroVersion = strings.Join(version[:], "")
-	}
-
-	service := "brave-base-" + dist[0] + "-" + distroVersion
-
-	baseConfig = BRAVEFILE
-
-	nameRegexp, _ := regexp.Compile("<name>")
-	serviceRegexp, _ := regexp.Compile("<service>")
-
-	baseConfig = nameRegexp.ReplaceAllString(baseConfig, name)
-	baseConfig = serviceRegexp.ReplaceAllString(baseConfig, service)
-
-	err := yaml.Unmarshal([]byte(baseConfig), &bravefile)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/constants.go
+++ b/shared/constants.go
@@ -1,17 +1,5 @@
 package shared
 
-// BRAVEFILE variable - minimal Bravefile template
-const BRAVEFILE = `
-base:
-  image: <name>
-  location: public
-
-service:
-  image: <service>
-  name: <service>
-  version: 1.0
-`
-
 const BraveHome = "/.bravetools"
 const BraveCertStore = BraveHome + "/certs"
 const BraveServerCertStore = BraveHome + "/servercerts"


### PR DESCRIPTION
Addresses https://github.com/bravetools/bravetools/issues/138

This PR separates the build section of the Bravefile from the Service section. This means it's now possible to build an image from a Bravefile that doesn't have a Service section at all.

Major Changes:
- Image field added to Build section of Bravefile - structure of <image_name>[/version][/arch] just like other Image fields.
- When building image, unit name will be generated from image name (no longer requires unit Name field from Service section)
- `brave base` no longer alters the name of the image being imported. It also applies same schema as above to extract metadata (<image_name>[/version][/arch]).

Minor:
- Fixes to tests
- Passing copies of bravefile/unitParams so host_api functions can mutate them safely.

Changes were largely made in a backwards compatible way - existing Bravefiles will continue to work.

If no Image value is provided in the build section, the Image field in the Service section will be used instead. Likewise, if no Image value is found in Service section during deploy, the build section Image field will be used - this means the Image field only needs to be defined once in the Bravefile, avoiding pointless repetition.