### PR TITLE
Remote resources

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -852,7 +852,7 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 	}
 
 	// Create an image based on running container and export it. Image saved as tar.gz in project local directory.
-	unitFingerprint, err := Publish(lxdServer, bravefile.PlatformService.Name, imageStruct.String())
+	unitFingerprint, err := Publish(lxdServer, bravefile.PlatformService.Name, "")
 	defer DeleteImageByFingerprint(lxdServer, unitFingerprint)
 	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("failed to publish image: " + err.Error())

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1090,8 +1090,11 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 	defer DeleteImageByFingerprint(lxdServer, fingerprint)
 
 	// Resource checks
-	// TODO: this should use a profile
-	err = CheckResources(imageStruct, backend, &unitParams, bh)
+	err = CheckMemory(lxdServer, unitParams.Resources.RAM)
+	if err != nil {
+		return err
+	}
+	err = CheckHostPorts(deployRemote.URL, unitParams.Ports)
 	if err != nil {
 		return err
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1087,9 +1087,19 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 	if err != nil {
 		return fmt.Errorf("failed to obtain image hash %q", unitParams.Image)
 	}
+	imgSize, err := localImageSize(imageStruct)
+	if err != nil {
+		return fmt.Errorf("failed to get image size for image %q", imageStruct.String())
+	}
 	defer DeleteImageByFingerprint(lxdServer, fingerprint)
 
 	// Resource checks
+	if unitParams.Storage != "" {
+		err = CheckStoragePoolSpace(lxdServer, unitParams.Storage, imgSize)
+		if err != nil {
+			return err
+		}
+	}
 	err = CheckMemory(lxdServer, unitParams.Resources.RAM)
 	if err != nil {
 		return err

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -729,7 +729,7 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 		if err != nil {
 			return err
 		}
-		err = CheckBackendDiskSpace(bh.Backend, img.Size)
+		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, img.Size)
 		if err != nil {
 			return err
 		}
@@ -774,7 +774,7 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 		if err != nil {
 			return err
 		}
-		err = CheckBackendDiskSpace(bh.Backend, imgSize)
+		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, imgSize)
 		if err != nil {
 			return err
 		}

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -810,8 +810,8 @@ func Stop(lxdServer lxd.InstanceServer, name string) error {
 }
 
 // Publish unit
-// lxc publish -f [remote]:[name] [remote]: --alias [name-version]
-func Publish(lxdServer lxd.InstanceServer, name string, version string) (fingerprint string, err error) {
+// lxc publish -f [remote]:[name] [remote]: --alias [name-suffix]
+func Publish(lxdServer lxd.InstanceServer, name string, suffix string) (fingerprint string, err error) {
 	operation := shared.Info("Publishing " + name)
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 	s.Suffix = " " + operation
@@ -864,7 +864,10 @@ func Publish(lxdServer lxd.InstanceServer, name string, version string) (fingerp
 	fingerprint = opAPI.Metadata["fingerprint"].(string)
 
 	aliasPost := api.ImageAliasesPost{}
-	aliasPost.Name = name + "-" + version
+	aliasPost.Name = name
+	if suffix != "" {
+		aliasPost.Name += "-" + suffix
+	}
 	aliasPost.Target = fingerprint
 	err = lxdServer.CreateImageAlias(aliasPost)
 	if err != nil {

--- a/platform/resources.go
+++ b/platform/resources.go
@@ -64,19 +64,6 @@ func CheckHostPorts(hostURL string, forwardedPorts []string) (err error) {
 	return nil
 }
 
-func getFreeSpace(storageUsage StorageUsage) (freeSpace int64, err error) {
-	usedStorageBytes, err := shared.SizeCountToInt(storageUsage.UsedStorage)
-	if err != nil {
-		return freeSpace, errors.New("failed to retrieve backend disk usage:" + err.Error())
-	}
-	totalStorageBytes, err := shared.SizeCountToInt(storageUsage.TotalStorage)
-	if err != nil {
-		return freeSpace, errors.New("failed to retrieve backend disk space:" + err.Error())
-	}
-
-	return totalStorageBytes - usedStorageBytes, nil
-}
-
 func CheckStoragePoolSpace(lxdServer lxd.InstanceServer, storagePool string, requestedSpace int64) (err error) {
 	res, err := lxdServer.GetStoragePoolResources(storagePool)
 	if err != nil {
@@ -91,25 +78,6 @@ func CheckStoragePoolSpace(lxdServer lxd.InstanceServer, storagePool string, req
 		}
 		return fmt.Errorf("requested size exceeds available space on storage pool - %q requested but %q available",
 			shared.FormatByteCountSI(requestedSpace), shared.FormatByteCountSI(int64(freeSpace)))
-	}
-
-	return nil
-}
-
-// CheckBackendDiskSpace checks whether backend has enough disk space for requested allocation
-func CheckBackendDiskSpace(backend Backend, requestedSpace int64) (err error) {
-	info, err := backend.Info()
-	if err != nil {
-		return errors.New("Failed to connect to host: " + err.Error())
-	}
-
-	freeSpace, err := getFreeSpace(info.Disk)
-	if err != nil {
-		return err
-	}
-
-	if requestedSpace >= freeSpace {
-		return errors.New("requested unit size exceeds available disk space on bravetools host. To increase storage pool size modify $HOME/.bravetools/config.yml and run brave configure")
 	}
 
 	return nil

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -51,8 +51,8 @@ func Color(colorString string) func(...interface{}) string {
 	return sprint
 }
 
-func ping(ip string, port string) error {
-	address, err := net.ResolveTCPAddr("tcp", ip+":"+port)
+func ping(host string, port string) error {
+	address, err := net.ResolveTCPAddr("tcp", host+":"+port)
 	if err != nil {
 		return err
 	}
@@ -71,9 +71,9 @@ func ping(ip string, port string) error {
 }
 
 // TCPPortStatus checks if multiple ports are available on the host
-func TCPPortStatus(ip string, ports []string) error {
+func TCPPortStatus(host string, ports []string) error {
 	for _, port := range ports {
-		err := ping(ip, port)
+		err := ping(host, port)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR makes the resource checks run by bravetools work on remote LXD instances, rather than only on the local backend.

If the remote doesn't have a specific storage device configured the early disk space check is skipped - an error will be raised when attempting to copy the image to the remote if it doesn't have sufficient space.