### PR TITLE
Remote `brave publish`

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -919,7 +919,13 @@ func (bh *BraveHost) PublishUnit(name string, backend Backend) error {
 		return errors.New("failed to get host info: " + err.Error())
 	}
 
-	lxdServer, err := GetLXDInstanceServer(bh.Remote)
+	remoteName, name := ParseRemoteName(name)
+	remote, err := LoadRemoteSettings(remoteName)
+	if err != nil {
+		return err
+	}
+
+	lxdServer, err := GetLXDInstanceServer(remote)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Make `brave publish` work with remote units - the images will be transferred over the network and saved to local disk.