### PR TITLE
Ensure local Backend running

### DIFF
--- a/platform/backend.go
+++ b/platform/backend.go
@@ -7,6 +7,7 @@ type Backend interface {
 	BraveBackendInit() error
 	Info() (Info, error)
 	Running() (bool, error)
+	Start() error
 }
 
 // Info describes Brave Platform

--- a/platform/backend.go
+++ b/platform/backend.go
@@ -6,6 +6,7 @@ import "fmt"
 type Backend interface {
 	BraveBackendInit() error
 	Info() (Info, error)
+	Running() (bool, error)
 }
 
 // Info describes Brave Platform

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -554,12 +554,9 @@ func (bh *BraveHost) DeleteUnit(name string) error {
 
 	// If local remote, ensure the VM is started
 	if remoteName == shared.BravetoolsRemote {
-		running, err := bh.Backend.Running()
+		err := bh.Backend.Start()
 		if err != nil {
-			return errors.New("Failed to get host info: " + err.Error())
-		}
-		if !running {
-			return errors.New("Backend is stopped")
+			return errors.New("Failed to start backend: " + err.Error())
 		}
 	}
 
@@ -950,12 +947,9 @@ func (bh *BraveHost) StopUnit(name string) error {
 
 	// If local remote, ensure the VM is started
 	if remoteName == shared.BravetoolsRemote {
-		running, err := bh.Backend.Running()
+		err := bh.Backend.Start()
 		if err != nil {
-			return errors.New("Failed to get host info: " + err.Error())
-		}
-		if !running {
-			return errors.New("Backend is stopped")
+			return errors.New("Failed to start backend: " + err.Error())
 		}
 	}
 
@@ -984,12 +978,9 @@ func (bh *BraveHost) StartUnit(name string) error {
 
 	// If local remote, ensure the VM is started
 	if remoteName == shared.BravetoolsRemote {
-		running, err := bh.Backend.Running()
+		err := bh.Backend.Start()
 		if err != nil {
-			return errors.New("Failed to get host info: " + err.Error())
-		}
-		if !running {
-			return errors.New("Backend is stopped")
+			return errors.New("Failed to start backend: " + err.Error())
 		}
 	}
 
@@ -1044,12 +1035,9 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 
 	// If local remote, check if running
 	if deployRemoteName == shared.BravetoolsRemote {
-		running, err := bh.Backend.Running()
+		err := bh.Backend.Start()
 		if err != nil {
-			return errors.New("Failed to get host info: " + err.Error())
-		}
-		if !running {
-			return errors.New("Backend is stopped")
+			return errors.New("Failed to start backend: " + err.Error())
 		}
 	}
 

--- a/platform/lxd.go
+++ b/platform/lxd.go
@@ -375,3 +375,8 @@ func (vm Lxd) Info() (Info, error) {
 
 	return backendInfo, nil
 }
+
+// Running returns whether backend is running
+func (vm Lxd) Running() (bool, error) {
+	return true, nil
+}

--- a/platform/lxd.go
+++ b/platform/lxd.go
@@ -380,3 +380,8 @@ func (vm Lxd) Info() (Info, error) {
 func (vm Lxd) Running() (bool, error) {
 	return true, nil
 }
+
+// Start starts the backend if it is not already running
+func (vm Lxd) Start() error {
+	return nil
+}

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -379,6 +379,31 @@ func (vm Multipass) Info() (backendInfo Info, err error) {
 	return backendInfo, nil
 }
 
+// Info shows all VMs and their state
+func (vm Multipass) Running() (bool, error) {
+	operation := shared.Info("Gathering multipass settings")
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
+	s.Suffix = " " + operation
+	s.Start()
+	defer s.Stop()
+
+	_, err := checkMultipass()
+
+	if err != nil {
+		return false, errors.New("multipass process not found: " + err.Error())
+	}
+
+	backendInfo, err := vm.getInfo()
+	if err != nil {
+		return false, errors.New("error contacting multipass vm: " + err.Error())
+	}
+
+	if backendInfo.State == "Running" {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (vm Multipass) getInfo() (Info, error) {
 
 	backendInfo := NewInfo()

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -404,6 +404,12 @@ func (vm Multipass) Running() (bool, error) {
 	return false, nil
 }
 
+// Start starts the backend if it is not already running
+func (vm Multipass) Start() error {
+	cmd := exec.Command("multipass", "start", vm.Settings.Name)
+	return cmd.Run()
+}
+
 func (vm Multipass) getInfo() (Info, error) {
 
 	backendInfo := NewInfo()


### PR DESCRIPTION
Instead of erroring when local backend is not running, it is a more seamless experience if bravetools automatically starts the backend for you.

An additional benefit of this when using the multipass backend is that most bravetools commands will become far more responsive. It takes far less than a second to start the VM if it is already running, making all basic commands run quicker (previous checks took several seconds).

Since starting the VM is so quick, a progress spinner will not be displayed usually - a spinner will be shown only if the `start` command takes longer than 1 second to complete.