### PR TITLE
Published image name

### DIFF
--- a/commands/publish.go
+++ b/commands/publish.go
@@ -6,11 +6,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var publishImageNames []string
+
 var bravePublish = &cobra.Command{
 	Use:   "publish <instance> [<instance>...]",
 	Short: "Publish deployed Units as images",
 	Long:  `Published Units will be saved in the current working directory as *.tar.gz file`,
 	Run:   publish,
+}
+
+func init() {
+	bravePublish.Flags().StringSliceVar(&publishImageNames, "image_name", []string{}, "Image names to apply to exported units")
 }
 
 func publish(cmd *cobra.Command, args []string) {
@@ -19,8 +25,12 @@ func publish(cmd *cobra.Command, args []string) {
 		log.Fatal("missing name - please provide unit name")
 	}
 
-	for _, name := range args {
-		err := host.PublishUnit(name)
+	for i, name := range args {
+		imageName := ""
+		if i < len(publishImageNames) {
+			imageName = publishImageNames[i]
+		}
+		err := host.PublishUnit(name, imageName)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/commands/publish.go
+++ b/commands/publish.go
@@ -20,7 +20,7 @@ func publish(cmd *cobra.Command, args []string) {
 	}
 
 	for _, name := range args {
-		err := host.PublishUnit(name, backend)
+		err := host.PublishUnit(name)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/commands/umount.go
+++ b/commands/umount.go
@@ -8,7 +8,7 @@ import (
 )
 
 var umountDir = &cobra.Command{
-	Use:   "umount UNIT:<path>",
+	Use:   "umount UNIT:<path> [UNIT:<path>...]",
 	Short: "Unmount device mounted on <path> from UNIT",
 	Long:  ``,
 	Run:   umount,

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -983,16 +983,18 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 }
 
 // PublishUnit publishes unit to image
-func (bh *BraveHost) PublishUnit(name string, backend Backend) error {
-	_, err := backend.Info()
-	if err != nil {
-		return errors.New("failed to get host info: " + err.Error())
-	}
-
+func (bh *BraveHost) PublishUnit(name string) error {
 	remoteName, name := ParseRemoteName(name)
 	remote, err := LoadRemoteSettings(remoteName)
 	if err != nil {
 		return err
+	}
+
+	if remote.Name == shared.BravetoolsRemote {
+		err := bh.Backend.Start()
+		if err != nil {
+			return errors.New("failed to get host info: " + err.Error())
+		}
 	}
 
 	lxdServer, err := GetLXDInstanceServer(remote)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -983,8 +983,8 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 }
 
 // PublishUnit publishes unit to image
-func (bh *BraveHost) PublishUnit(name string) error {
-	remoteName, name := ParseRemoteName(name)
+func (bh *BraveHost) PublishUnit(unitName string, imageName string) error {
+	remoteName, unitName := ParseRemoteName(unitName)
 	remote, err := LoadRemoteSettings(remoteName)
 	if err != nil {
 		return err
@@ -1002,19 +1002,22 @@ func (bh *BraveHost) PublishUnit(name string) error {
 		return err
 	}
 
-	timestamp := time.Now()
+	if imageName == "" {
+		timestamp := time.Now()
+		imageName = unitName + "-" + timestamp.Format("20060102150405")
+	}
 
 	// Create an image based on running container and export it. Image saved as tar.gz in project local directory.
-	fmt.Printf("Publishing unit %q\n", name)
+	fmt.Printf("Publishing unit %q as image %q\n", unitName, imageName)
 
-	unitFingerprint, err := Publish(lxdServer, name, timestamp.Format("20060102150405"))
+	unitFingerprint, err := Publish(lxdServer, unitName, imageName)
 	defer DeleteImageByFingerprint(lxdServer, unitFingerprint)
 	if err != nil {
 		return errors.New("failed to publish image: " + err.Error())
 	}
 
 	fmt.Println("Exporting archive ...")
-	err = ExportImage(lxdServer, unitFingerprint, name+"-"+timestamp.Format("20060102150405"))
+	err = ExportImage(lxdServer, unitFingerprint, imageName)
 	if err != nil {
 		return errors.New("failed to export unit: " + err.Error())
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1004,11 +1004,17 @@ func (bh *BraveHost) PublishUnit(unitName string, imageName string) error {
 
 	if imageName == "" {
 		timestamp := time.Now()
-		imageName = unitName + "-" + timestamp.Format("20060102150405")
+		imageName = unitName + "/" + timestamp.Format("20060102150405")
 	}
 
+	imageStruct, err := ParseImageString(imageName)
+	if err != nil {
+		return fmt.Errorf("failed to parse image string %q: %s", imageName, err)
+	}
+	imageName = imageStruct.ToBasename()
+
 	// Create an image based on running container and export it. Image saved as tar.gz in project local directory.
-	fmt.Printf("Publishing unit %q as image %q\n", unitName, imageName)
+	fmt.Printf("Publishing unit %q as image %q\n", unitName, imageName+".tar.gz")
 
 	unitFingerprint, err := Publish(lxdServer, unitName, imageName)
 	defer DeleteImageByFingerprint(lxdServer, unitFingerprint)

--- a/platform/images.go
+++ b/platform/images.go
@@ -106,7 +106,7 @@ func validImageName(imageStruct BravetoolsImage) bool {
 }
 
 func validImageFieldChar(char rune) bool {
-	// Alpha-numeric is fine, along with '-' and '.
+	// Alpha-numeric is fine, along with '-' and '.'
 	if !unicode.IsLetter(char) && !unicode.IsNumber(char) && char != '-' && char != '.' {
 		return false
 	}

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -812,8 +812,8 @@ func Stop(lxdServer lxd.InstanceServer, name string) error {
 }
 
 // Publish unit
-// lxc publish -f [remote]:[name] [remote]: --alias [name-suffix]
-func Publish(lxdServer lxd.InstanceServer, name string, suffix string) (fingerprint string, err error) {
+// lxc publish -f [remote]:[name] [remote]: --alias [image]
+func Publish(lxdServer lxd.InstanceServer, name string, image string) (fingerprint string, err error) {
 	operation := shared.Info("Publishing " + name)
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 	s.Suffix = " " + operation
@@ -866,9 +866,9 @@ func Publish(lxdServer lxd.InstanceServer, name string, suffix string) (fingerpr
 	fingerprint = opAPI.Metadata["fingerprint"].(string)
 
 	aliasPost := api.ImageAliasesPost{}
-	aliasPost.Name = name
-	if suffix != "" {
-		aliasPost.Name += "-" + suffix
+	aliasPost.Name = image
+	if aliasPost.Name != "" {
+		aliasPost.Name = name
 	}
 	aliasPost.Target = fingerprint
 	err = lxdServer.CreateImageAlias(aliasPost)


### PR DESCRIPTION
Publishing a unit as an image with `brave publish` now allows for naming the exported images using the new bravetools image field syntax: <image_name>[/version][/arch].

The exported image files now use the same format as bravetools image store for consistency, delimiting with underscore ("_") instead of the old legacy design that used a hypen ("-"). If no image string is provided, the default will be to export the unit as `unit_name/$timestamp` just like it is currently. This image_name/version will be preserved when the image file is imported with `brave import`.

Since the `brave publish` command can export multiple units at once, you can provide multiple image names to apply to the exported images at the CLI. This can be done either by delimiting the image names with commas or by providing the "image_name" flag multiple times.


Example:
```sh
#publish units as images
brave publish test test-service test-service2 --image_name imagename/edit,imagename/edit2,imagename/edit3
Publishing unit "test" as image "imagename_edit_amd64.tar.gz"
Exporting archive ...
Cleaning ...
Publishing unit "test-service" as image "imagename_edit2_amd64.tar.gz"
Exporting archive ...
Cleaning ...
Publishing unit "test-service2" as image "imagename_edit3_amd64.tar.gz"
Exporting archive ...
Cleaning ... 

#brave import on a new image file
brave import ./imagename_edit_amd64.tar.gz
8195c85a20f8ab2d1f5084a1b744363a

#check the image was imported correctly
brave image
IMAGE                           VERSION         ARCH    CREATED         SIZE    HASH
imagename                       edit            amd64   just now        28MB    8195c85a20f8ab2d1f5084a1b744363a
```

Alternative syntax for labelling multiple exported images:
```
brave publish test test-service test-service2 --image_name imagename/edit --image_name imagename/edit2 --image_name imagename/edit3
```