### PR TITLE
add image name to avoid error during brave base

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -922,7 +922,7 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 	}
 
 	// Create an image based on running container and export it. Image saved as tar.gz in project local directory.
-	unitFingerprint, err := Publish(lxdServer, bravefile.PlatformService.Name, "")
+	unitFingerprint, err := Publish(lxdServer, bravefile.PlatformService.Name, imageStruct.ToBasename())
 	defer DeleteImageByFingerprint(lxdServer, unitFingerprint)
 	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("failed to publish image: " + err.Error())

--- a/platform/images.go
+++ b/platform/images.go
@@ -278,6 +278,7 @@ func GetBravefileFromLXD(name string) (*shared.Bravefile, error) {
 		return nil, err
 	}
 
+	bravefile.Image = image.String()
 	bravefile.Base.Image = image.String()
 	bravefile.Base.Location = "public"
 


### PR DESCRIPTION
Small fix that avoids `failed to publish image: name and target are required` error during `brave base`