### PR TITLE
Clean filepaths when mounting

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -52,6 +52,9 @@ func createSharedVolume(lxdServer lxd.InstanceServer,
 	destUnit string,
 	destPath string) error {
 
+	sourcePath = cleanMountTargetPath(sourcePath)
+	destPath = cleanMountTargetPath(destPath)
+
 	volumeName := getDiskDeviceHash(sourceUnit, sourcePath)
 
 	newVolume := api.StorageVolumesPost{
@@ -523,8 +526,16 @@ func getBuildDependents(dependency string, composeFile *shared.ComposeFile) (ser
 	return serviceNames, nil
 }
 
-func getDiskDeviceHash(unitName string, path string) string {
-	// Clean path by removing leading and trailing slashes
-	path = strings.TrimSuffix(strings.TrimPrefix(path, "/"), "/")
-	return "brave_" + fmt.Sprintf("%x", sha256.Sum224([]byte(unitName+path)))
+func getDiskDeviceHash(unitName string, targetPath string) string {
+	targetPath = cleanMountTargetPath(targetPath)
+	return "brave_" + fmt.Sprintf("%x", sha256.Sum224([]byte(unitName+targetPath)))
+}
+
+func cleanMountTargetPath(targetPath string) string {
+	targetPath = filepath.ToSlash(targetPath)
+	targetPath = path.Clean(targetPath)
+	if !strings.HasPrefix(targetPath, "/") {
+		targetPath = "/" + targetPath
+	}
+	return targetPath
 }

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -408,6 +408,7 @@ func (bh *BraveHost) UmountShare(unit string, target string) error {
 	}
 
 	// Device name is derived from unit and target path
+	target = cleanMountTargetPath(target)
 	deviceName := getDiskDeviceHash(unit, target)
 
 	switch backend {
@@ -507,8 +508,7 @@ func (bh *BraveHost) MountShare(source string, destUnit string, destPath string)
 		}
 	}
 
-	destPath = filepath.ToSlash(destPath)
-	destPath = strings.TrimSuffix(strings.TrimPrefix(destPath, "/"), "/")
+	destPath = cleanMountTargetPath(destPath)
 
 	// Unit-to-unit volume creation and mounting is same across backends
 	if sourceUnit != "" {

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -299,6 +299,9 @@ func MountDirectory(lxdServer lxd.InstanceServer, sourcePath string, destUnit st
 		return err
 	}
 
+	sourcePath = path.Clean(sourcePath)
+
+	destPath = cleanMountTargetPath(destPath)
 	hashStr := getDiskDeviceHash(destUnit, destPath)
 
 	devname := hashStr


### PR DESCRIPTION
Cleaning the paths properly avoids issues with different representations of the same path getting different hashes. Cleaning each path returns the shortest valid path, dealing with issues caused by using `..` in paths.

For example, the mount point "/root" would be hashed differently from "/root/../root" despite referring to the same directory. When unmounting, the exact same representation of the path used when originally mounting would have to be used. Cleaning the paths avoids these issues.

See [Rob Pike, "Lexical File Names in Plan 9 or Getting Dot-Dot Right"](https://9p.io/sys/doc/lexnames.html).