### PR TITLE
Remote image deploy

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -528,3 +528,55 @@ func getDiskDeviceHash(unitName string, path string) string {
 	path = strings.TrimSuffix(strings.TrimPrefix(path, "/"), "/")
 	return "brave_" + fmt.Sprintf("%x", sha256.Sum224([]byte(unitName+path)))
 }
+
+// importImageFile imports an LXD image file in the local directory into the bravetools image store
+// The image file is cleaned up afterwards.
+func importImageFile(ctx context.Context, imageStruct BravetoolsImage) error {
+	home, _ := os.UserHomeDir()
+	localImageFile := imageStruct.ToBasename() + ".tar.gz"
+	localHashFile := localImageFile + ".md5"
+
+	defer func() {
+		if err := os.Remove(localImageFile); err != nil {
+			fmt.Println("failed to clean up image archive: " + err.Error())
+		}
+	}()
+
+	imageHash, err := shared.FileHash(localImageFile)
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return errors.New("failed to generate image hash: " + err.Error())
+	}
+
+	fmt.Println(imageHash)
+
+	// Write image hash to a file
+	f, err := os.Create(localHashFile)
+	if err != nil {
+		return errors.New(err.Error())
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			fmt.Println("failed to close image hash file: " + err.Error())
+		}
+		if err := os.Remove(localHashFile); err != nil {
+			fmt.Println("failed to clean up image hash: " + err.Error())
+		}
+	}()
+
+	_, err = f.WriteString(imageHash)
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return errors.New(err.Error())
+	}
+
+	err = shared.CopyFile(localImageFile, path.Join(home, shared.ImageStore, localImageFile))
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return errors.New("failed to copy image archive to local storage: " + err.Error())
+	}
+
+	err = shared.CopyFile(localHashFile, path.Join(home, shared.ImageStore, localHashFile))
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return errors.New("failed to copy images hash into local storage: " + err.Error())
+	}
+
+	return nil
+}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -980,6 +980,25 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 		return errors.New("failed to copy image file to bravetools image store: " + err.Error())
 	}
 
+	// If imagename to build includes a remote, as last step in build push image to remote LXD server
+	destRemoteName, _ := ParseRemoteName(imageString)
+	if destRemoteName != shared.BravetoolsRemote {
+		destRemote, err := LoadRemoteSettings(destRemoteName)
+		if err != nil {
+			return err
+		}
+
+		destServer, err := GetLXDInstanceServer(destRemote)
+		if err != nil {
+			return err
+		}
+
+		err = CopyImage(lxdServer, destServer, imageFingerprint, imageStruct.String())
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1146,7 +1146,14 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		bravefile.PlatformService.Image = imageStruct.String()
 
 		err = bh.BuildImage(*bravefile)
-		if err != nil {
+		switch errType := err.(type) {
+		case nil:
+		case *ImageExistsError:
+			// If image already exists continue and log the skip
+			err = nil
+			fmt.Printf("image %q already exists locally - skipping remote import\n", errType.Name)
+		default:
+			// Stop on unknown err
 			return err
 		}
 	}

--- a/platform/images.go
+++ b/platform/images.go
@@ -279,18 +279,27 @@ func resolveBaseImageLocation(imageString string) (location string, err error) {
 	return "", fmt.Errorf("image %q location could not be resolved", imageString)
 }
 
-// GetBravefileFromLXD generates a Bravefile for import of images from LXD repository
+// GetBravefileFromLXD generates a Bravefile for import of images from an LXD server
 func GetBravefileFromLXD(name string) (*shared.Bravefile, error) {
-	bravefile := shared.NewBravefile()
+	imageRemoteName, name := ParseRemoteName(name)
 
 	image, err := ParseImageString(name)
 	if err != nil {
 		return nil, err
 	}
 
+	baseImageName := image.String()
+	baseLocation := "public"
+	if imageRemoteName != shared.BravetoolsRemote {
+		baseImageName = imageRemoteName + ":" + baseImageName
+		baseLocation = "private"
+	}
+
+	bravefile := shared.NewBravefile()
+
 	bravefile.Image = image.String()
-	bravefile.Base.Image = image.String()
-	bravefile.Base.Location = "public"
+	bravefile.Base.Image = baseImageName
+	bravefile.Base.Location = baseLocation
 
 	bravefile.PlatformService.Name = ""
 	bravefile.PlatformService.Image = image.String()

--- a/platform/images.go
+++ b/platform/images.go
@@ -248,6 +248,16 @@ func resolveBaseImageLocation(imageString string) (location string, err error) {
 		return "local", nil
 	}
 
+	remoteList, err := ListRemotes()
+	if err != nil {
+		return "", err
+	}
+	for _, remoteName := range remoteList {
+		if remote == remoteName {
+			return "private", nil
+		}
+	}
+
 	// Check for legacy image field
 	imageStruct, err = ParseLegacyImageString(imageString)
 	if err != nil {

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -1147,7 +1147,7 @@ func CopyImage(sourceServer lxd.InstanceServer, destServer lxd.InstanceServer, f
 	}
 
 	args := &lxd.ImageCopyArgs{
-		Mode: "push",
+		Mode: "relay",
 	}
 
 	op, err := destServer.CopyImage(sourceServer, *img, args)


### PR DESCRIPTION
This PR enables use of image stored in remote LXD servers in Bravefiles. These remote images can be used as "Base" images during build or as "source" images during container deployment. In addition, during the build phase it is now possible to push the resulting image into a remote LXD server.

An example Bravefile using these features:
```yaml
image: store:test-image/1.0
base:
  image: store:alpine/edge

service:
  name: deploy:python-api
```
**During build:**
The "store" remote provides the base image for the build phase ("alpine/edge"). The resulting image "test-image/1.0" is built and then pushed into the "store" remote server.

**During deploy:**
The "store" remote holds the source image "test-image/1.0" to be deployed as a container. If bravetools does not have a local copy of the image already it will import it from the "store" remote. Then the resulting container will be pushed to the "deploy" remote.


Bravetools will always make a local copy of images it imports when possible, whether during build or if deploying a remotely stored image. _Local images will be prioritized over remotely stored images if present_; this last point may be debated - perhaps it's better to do the opposite and favour remote images by default instead? Or perhaps some validation could be done like checking fingerprints.

The mechanism used to import these images is the same as `brave base`, meaning a container will be spun up and turned into an image and exported as a single .tar.gz file.