### PR TITLE
Remote build fixes

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"os/user"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/bravetools/bravetools/shared"
 	lxd "github.com/lxc/lxd/client"
@@ -96,6 +98,298 @@ func createSharedVolume(lxdServer lxd.InstanceServer,
 	err = AddDevice(lxdServer, destUnit, destDeviceName, destShareSettings)
 	if err != nil {
 		return errors.New("failed to mount to destination: " + err.Error())
+	}
+
+	return nil
+}
+
+func needTransferImage(bravefile shared.Bravefile) bool {
+	// The image to build - if not in build section, use Image defined in Service section
+	imageString := bravefile.Image
+	if imageString == "" {
+		imageString = bravefile.PlatformService.Image
+	}
+
+	destRemoteName, _ := ParseRemoteName(imageString)
+
+	// If no remote store specified for image nothing to do
+	return destRemoteName != shared.BravetoolsRemote
+}
+
+func buildImage(bh *BraveHost, bravefile shared.Bravefile) error {
+
+	var imageStruct BravetoolsImage
+	var err error
+
+	// The image to build - if not in build section, use Image defined in Service section
+	imageString := bravefile.Image
+	if imageString == "" {
+		imageString = bravefile.PlatformService.Image
+	}
+
+	err = bravefile.ValidateBuild()
+	if err != nil {
+		return fmt.Errorf("failed to build image: %s", err)
+	}
+
+	// If version explicitly provided separately this is a legacy Bravefile
+	if bravefile.PlatformService.Version == "" || bravefile.Image != "" {
+		imageStruct, err = ParseImageString(imageString)
+	} else {
+		imageStruct, err = ParseLegacyImageString(imageString)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Image architecture must match base image architecture
+	baseImageStruct, err := ParseImageString(bravefile.Base.Image)
+	if err != nil {
+		return err
+	}
+	if imageStruct.Architecture != baseImageStruct.Architecture {
+		return fmt.Errorf("target image architecture [%s] does not match base image [%s]", imageStruct.Architecture, baseImageStruct.Architecture)
+	}
+
+	// Use bravetools host LXD instance to build
+	lxdServer, err := GetLXDInstanceServer(bh.Remote)
+	if err != nil {
+		return err
+	}
+
+	// Intercept SIGINT, propagate cancel and cleanup artefacts
+	var imageFingerprint string
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		for range c {
+			fmt.Println("Interrupting build and cleaning artefacts")
+			cancel()
+		}
+	}()
+
+	// If image already exists in local store, check for remote dest - if exists, push image there, else error
+	if imageExists(imageStruct) {
+		return &ImageExistsError{Name: imageStruct.String()}
+	}
+
+	fmt.Println(shared.Info("Building Image: " + imageStruct.String()))
+
+	bravefile.PlatformService.Name = "brave-build-" + strings.ReplaceAll(strings.ReplaceAll(imageStruct.ToBasename(), "_", "-"), ".", "-")
+
+	err = checkUnits(lxdServer, bravefile.PlatformService.Name, bh.Remote.Profile)
+	if err != nil {
+		return err
+	}
+
+	// Setup build cleanup code
+	defer func() {
+		DeleteUnit(lxdServer, bravefile.PlatformService.Name)
+		DeleteImageByFingerprint(lxdServer, imageFingerprint)
+	}()
+
+	// If base image location not provided, attempt to infer it
+	if bravefile.Base.Location == "" {
+		bravefile.Base.Location, err = resolveBaseImageLocation(bravefile.Base.Image)
+		if err != nil {
+			return fmt.Errorf("base image %q does not exist: %s", bravefile.Base.Image, err.Error())
+		}
+	}
+
+	switch bravefile.Base.Location {
+	case "public":
+		// Check disk space
+		publicLxd, err := GetSimplestreamsLXDSever("https://images.linuxcontainers.org", nil)
+		if err != nil {
+			return err
+		}
+
+		img, err := GetImageByAlias(publicLxd, bravefile.Base.Image)
+		if err != nil {
+			return err
+		}
+		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, img.Size)
+		if err != nil {
+			return err
+		}
+
+		imageFingerprint, err = importLXD(ctx, lxdServer, &bravefile, bh.Remote.Profile)
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return err
+		}
+
+		err = Start(lxdServer, bravefile.PlatformService.Name)
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return err
+		}
+	case "github":
+		imageFingerprint, err = importGitHub(ctx, lxdServer, &bravefile, bh, bh.Remote.Profile, bh.Remote.Storage)
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return err
+		}
+
+		err = Start(lxdServer, bravefile.PlatformService.Name)
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return err
+		}
+	case "local":
+		// Check disk space
+		localBaseImage, err := ParseImageString(bravefile.Base.Image)
+		if err != nil {
+			return err
+		}
+		if !imageExists(localBaseImage) {
+			// Check legacy bravefile
+			legacyLocalBaseImage, err := ParseLegacyImageString(bravefile.Base.Image)
+			if err == nil {
+				if !imageExists(legacyLocalBaseImage) {
+					return fmt.Errorf("base image %q required for building image %q does not exist", legacyLocalBaseImage.String(), imageStruct.String())
+				}
+			} else {
+				return fmt.Errorf("base image %q required for building image %q does not exist", localBaseImage.String(), imageStruct.String())
+			}
+		}
+
+		imgSize, err := localImageSize(localBaseImage)
+		if err != nil {
+			return err
+		}
+		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, imgSize)
+		if err != nil {
+			return err
+		}
+
+		imageFingerprint, err = importLocal(ctx, lxdServer, &bravefile, bh.Remote.Profile, bh.Remote.Storage)
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return err
+		}
+	case "private":
+		var imageRemoteName string
+		imageRemoteName, bravefile.Base.Image = ParseRemoteName(bravefile.Base.Image)
+
+		imageRemote, err := LoadRemoteSettings(imageRemoteName)
+		if err != nil {
+			return err
+		}
+
+		// Connect to remote server - authenticate if not public
+		var imageRemoteServer lxd.ImageServer
+		if imageRemote.Public {
+			imageRemoteServer, err = GetLXDImageSever(imageRemote)
+		} else {
+			imageRemoteServer, err = GetLXDInstanceServer(imageRemote)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		img, err := GetImageByAlias(imageRemoteServer, bravefile.Base.Image)
+		if err != nil {
+			return err
+		}
+		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, img.Size)
+		if err != nil {
+			return err
+		}
+
+		imageFingerprint, err = importLXD(ctx, lxdServer, &bravefile, bh.Remote.Profile)
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return err
+		}
+
+		err = Start(lxdServer, bravefile.PlatformService.Name)
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("base image location %q not supported", bravefile.Base.Location)
+	}
+
+	pMan := bravefile.SystemPackages.Manager
+
+	switch pMan {
+	case "":
+		// No package manager - if packages are to be installed, raise error
+		if len(bravefile.SystemPackages.System) > 0 {
+			return errors.New("package manager not specified - cannot install packages")
+		}
+	case "apk":
+		_, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, []string{"apk", "update", "--no-cache"}, ExecArgs{})
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return errors.New("failed to update repositories: " + err.Error())
+		}
+
+		args := []string{"apk", "--no-cache", "add"}
+		args = append(args, bravefile.SystemPackages.System...)
+
+		if len(args) > 3 {
+			status, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, args, ExecArgs{})
+
+			if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+				return errors.New("failed to install packages: " + err.Error())
+			}
+			if status > 0 {
+				return errors.New(shared.Fatal("failed to install packages"))
+			}
+		}
+
+	case "apt":
+		_, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, []string{"apt", "update"}, ExecArgs{})
+		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+			return errors.New("failed to update repositories: " + err.Error())
+		}
+
+		args := []string{"apt", "install"}
+		args = append(args, bravefile.SystemPackages.System...)
+
+		if len(args) > 2 {
+			args = append(args, "--yes")
+			status, err := Exec(ctx, lxdServer, bravefile.PlatformService.Name, args, ExecArgs{})
+
+			if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+				return errors.New("failed to install packages: " + err.Error())
+			}
+			if status > 0 {
+				return errors.New(shared.Fatal("failed to install packages"))
+			}
+		}
+	default:
+		return fmt.Errorf("package manager %q not recognized", pMan)
+	}
+
+	// Go through "Copy" section
+	err = bravefileCopy(ctx, lxdServer, bravefile.Copy, bravefile.PlatformService.Name)
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return err
+	}
+
+	// Go through "Run" section
+	err = bravefileRun(ctx, lxdServer, bravefile.Run, bravefile.PlatformService.Name)
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return errors.New(shared.Fatal("failed to execute command: " + err.Error()))
+	}
+
+	// Create an image based on running container and export it. Image saved as tar.gz in project local directory.
+	unitFingerprint, err := Publish(lxdServer, bravefile.PlatformService.Name, imageStruct.ToBasename())
+	defer DeleteImageByFingerprint(lxdServer, unitFingerprint)
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return errors.New("failed to publish image: " + err.Error())
+	}
+
+	err = ExportImage(lxdServer, unitFingerprint, imageStruct.ToBasename())
+	if err := shared.CollectErrors(err, ctx.Err()); err != nil {
+		return errors.New("failed to export image: " + err.Error())
+	}
+
+	err = importImageFile(ctx, imageStruct)
+	if err != nil {
+		return errors.New("failed to copy image file to bravetools image store: " + err.Error())
 	}
 
 	return nil

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -697,77 +697,6 @@ func (bh *BraveHost) DeleteUnit(name string) error {
 	return nil
 }
 
-func (bh *BraveHost) TransferImage(bravefile shared.Bravefile) error {
-	var imageStruct BravetoolsImage
-	var err error
-
-	// The image to build - if not in build section, use Image defined in Service section
-	imageString := bravefile.Image
-	if imageString == "" {
-		imageString = bravefile.PlatformService.Image
-	}
-
-	// If version explicitly provided separately this is a legacy Bravefile
-	if bravefile.PlatformService.Version == "" || bravefile.Image != "" {
-		imageStruct, err = ParseImageString(imageString)
-	} else {
-		imageStruct, err = ParseLegacyImageString(imageString)
-	}
-	if err != nil {
-		return err
-	}
-
-	imgPath, err := getImageFilepath(imageStruct)
-	if err != nil {
-		return err
-	}
-
-	destRemoteName, _ := ParseRemoteName(imageString)
-
-	// If no remote store specified for image nothing to do
-	if destRemoteName == shared.BravetoolsRemote {
-		return nil
-	}
-
-	// Use bravetools host LXD instance to build
-	lxdServer, err := GetLXDInstanceServer(bh.Remote)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(shared.Info(fmt.Sprintf("Pushing image to remote %q", destRemoteName)))
-
-	destRemote, err := LoadRemoteSettings(destRemoteName)
-	if err != nil {
-		return err
-	}
-
-	destServer, err := GetLXDInstanceServer(destRemote)
-	if err != nil {
-		return err
-	}
-
-	// Import image to local LXD server to transfer to remote
-	imageFingerprint, err := ImportImage(lxdServer, imgPath, imageStruct.String())
-	if err != nil {
-		return err
-	}
-
-	// If the remote to push image to is not the same as bravehost remote, cleanup and push
-	if bh.Remote.Name != destRemoteName {
-		defer func() {
-			DeleteImageByFingerprint(lxdServer, imageFingerprint)
-		}()
-
-		err = CopyImage(lxdServer, destServer, imageFingerprint, imageStruct.String())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 type ImageExistsError struct {
 	Name string
 }
@@ -790,7 +719,7 @@ func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
 		return err
 	}
 
-	return bh.TransferImage(bravefile)
+	return TransferImage(bh.Remote, bravefile)
 }
 
 // PublishUnit publishes unit to image

--- a/platform/images.go
+++ b/platform/images.go
@@ -253,18 +253,17 @@ func resolveBaseImageLocation(imageString string) (location string, err error) {
 		return "", err
 	}
 	for _, remoteName := range remoteList {
-		if remote == remoteName {
+		if remote == remoteName && remote != shared.BravetoolsRemote {
 			return "private", nil
 		}
 	}
 
 	// Check for legacy image field
 	imageStruct, err = ParseLegacyImageString(imageString)
-	if err != nil {
-		return "", err
-	}
-	if imageExists(imageStruct) {
-		return "local", nil
+	if err == nil {
+		if imageExists(imageStruct) {
+			return "local", nil
+		}
 	}
 
 	// Query public remote for alias

--- a/platform/images.go
+++ b/platform/images.go
@@ -61,6 +61,9 @@ func ParseImageString(imageString string) (imageStruct BravetoolsImage, err erro
 }
 
 func ParseLegacyImageString(imageString string) (imageStruct BravetoolsImage, err error) {
+	// Remove remote if present
+	_, imageString = ParseRemoteName(imageString)
+
 	// Legacy Bravefile - these have the version prepended to end of name and no arch
 	split := strings.Split(imageString, "-")
 	if split[0] == "" {

--- a/test/compose/compose_test.go
+++ b/test/compose/compose_test.go
@@ -10,10 +10,13 @@ import (
 )
 
 func TestCompose(t *testing.T) {
-	host, err := *platform.NewBraveHost()
-	backend, err := platform.NewHostBackend(host)
+	host, err := platform.NewBraveHost()
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
+	}
+	backend, err := platform.NewHostBackend(host.Settings)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	os.Chdir("python-multi-service")


### PR DESCRIPTION
A series of fixes targeting issues with the new remote image stores.
- Fix inference of base image location
- Update parsing of legacy image strings to handle remotes, fix errors raised by attempt to parse legacy string
- Splitting image and and transfer into two separate functions to avoid conflicts between the two. Hopefully addresses https://github.com/bravetools/bravetools/issues/196