### PR TITLE
Accurate architectures and image matching

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -176,7 +176,7 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 	}()
 
 	// If image already exists in local store, check for remote dest - if exists, push image there, else error
-	if _, err := getLocalImageFilepath(imageStruct); err == nil {
+	if _, err := localImagePath(imageStruct); err == nil {
 		return &ImageExistsError{Name: imageStruct.String()}
 	}
 
@@ -246,12 +246,12 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		if err != nil {
 			return err
 		}
-		if _, err = queryLocalImageFilepath(localBaseImage); err != nil {
+		if _, err = matchLocalImagePath(localBaseImage); err != nil {
 			// Check legacy bravefile
 			var parseErr error
 			localBaseImage, parseErr = ParseLegacyImageString(bravefile.Base.Image)
 			if parseErr == nil {
-				if _, legacyErr := queryLocalImageFilepath(localBaseImage); legacyErr != nil {
+				if _, legacyErr := matchLocalImagePath(localBaseImage); legacyErr != nil {
 					return legacyErr
 				}
 			} else {
@@ -446,7 +446,7 @@ func TransferImage(sourceRemote Remote, bravefile shared.Bravefile) error {
 		imageStruct.Version = defaultImageVersion
 	}
 
-	imgPath, err := getLocalImageFilepath(imageStruct)
+	imgPath, err := localImagePath(imageStruct)
 	if err != nil {
 		return err
 	}
@@ -522,7 +522,7 @@ func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *
 		return fingerprint, err
 	}
 
-	if _, err = queryLocalImageFilepath(imageStruct); err != nil {
+	if _, err = matchLocalImagePath(imageStruct); err != nil {
 		err = bh.BuildImage(*remoteBravefile)
 		if err != nil {
 			return fingerprint, err
@@ -551,7 +551,7 @@ func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *s
 		return "", err
 	}
 
-	path, err := queryLocalImageFilepath(imageStruct)
+	path, err := matchLocalImagePath(imageStruct)
 	if err != nil {
 		return "", err
 	}
@@ -897,7 +897,7 @@ func getBuildDependents(dependency string, composeFile *shared.ComposeFile) (ser
 			return serviceNames, err
 		}
 
-		if _, err = queryLocalImageFilepath(imageStruct); err == nil {
+		if _, err = matchLocalImagePath(imageStruct); err == nil {
 			continue
 		}
 		for _, dependsOn := range composeFile.Services[service].Depends {

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -267,7 +267,8 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		}
 		if _, err = queryLocalImageFilepath(localBaseImage); err != nil {
 			// Check legacy bravefile
-			localBaseImage, parseErr := ParseLegacyImageString(bravefile.Base.Image)
+			var parseErr error
+			localBaseImage, parseErr = ParseLegacyImageString(bravefile.Base.Image)
 			if parseErr == nil {
 				if _, legacyErr := queryLocalImageFilepath(localBaseImage); legacyErr != nil {
 					return legacyErr

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -148,13 +148,16 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		return err
 	}
 
-	// Set output image architecture based on server arch if not provided
+	// Set output image architecture based on server arch if not provided and set default version if missing
 	buildServerArch, err := GetLXDServerArch(lxdServer)
 	if err != nil {
 		return err
 	}
 	if imageStruct.Architecture == "" {
 		imageStruct.Architecture = buildServerArch
+	}
+	if imageStruct.Version == "" {
+		imageStruct.Version = defaultImageVersion
 	}
 
 	// Since we spin up base container to build new one, must match build server arch
@@ -449,11 +452,6 @@ func TransferImage(sourceRemote Remote, bravefile shared.Bravefile) error {
 		return err
 	}
 
-	imgPath, err := getLocalImageFilepath(imageStruct)
-	if err != nil {
-		return err
-	}
-
 	destRemoteName, _ := ParseRemoteName(imageString)
 
 	// If no remote store specified for image nothing to do
@@ -463,6 +461,23 @@ func TransferImage(sourceRemote Remote, bravefile shared.Bravefile) error {
 
 	// Use bravetools host LXD instance to build
 	lxdServer, err := GetLXDInstanceServer(sourceRemote)
+	if err != nil {
+		return err
+	}
+
+	// Set output image architecture based on server arch if not provided and set default version if missing
+	buildServerArch, err := GetLXDServerArch(lxdServer)
+	if err != nil {
+		return err
+	}
+	if imageStruct.Architecture == "" {
+		imageStruct.Architecture = buildServerArch
+	}
+	if imageStruct.Version == "" {
+		imageStruct.Version = defaultImageVersion
+	}
+
+	imgPath, err := getLocalImageFilepath(imageStruct)
 	if err != nil {
 		return err
 	}

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -149,11 +149,11 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 	}
 
 	// Set output image architecture based on server arch if not provided and set default version if missing
-	buildServerArch, err := GetLXDServerArch(lxdServer)
-	if err != nil {
-		return err
-	}
 	if imageStruct.Architecture == "" {
+		buildServerArch, err := GetLXDServerArch(lxdServer)
+		if err != nil {
+			return err
+		}
 		imageStruct.Architecture = buildServerArch
 	}
 	if imageStruct.Version == "" {
@@ -435,11 +435,11 @@ func TransferImage(sourceRemote Remote, bravefile shared.Bravefile) error {
 	}
 
 	// Set output image architecture based on server arch if not provided and set default version if missing
-	buildServerArch, err := GetLXDServerArch(lxdServer)
-	if err != nil {
-		return err
-	}
 	if imageStruct.Architecture == "" {
+		buildServerArch, err := GetLXDServerArch(lxdServer)
+		if err != nil {
+			return err
+		}
 		imageStruct.Architecture = buildServerArch
 	}
 	if imageStruct.Version == "" {

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -262,11 +262,11 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		if err != nil {
 			return err
 		}
-		if _, err = getLocalImageFilepath(localBaseImage); err != nil {
+		if _, err = queryLocalImageFilepath(localBaseImage); err != nil {
 			// Check legacy bravefile
 			localBaseImage, parseErr := ParseLegacyImageString(bravefile.Base.Image)
 			if parseErr == nil {
-				if _, legacyErr := getLocalImageFilepath(localBaseImage); legacyErr != nil {
+				if _, legacyErr := queryLocalImageFilepath(localBaseImage); legacyErr != nil {
 					return legacyErr
 				}
 			} else {
@@ -538,7 +538,7 @@ func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *
 		return fingerprint, err
 	}
 
-	if _, err = getLocalImageFilepath(imageStruct); err != nil {
+	if _, err = queryLocalImageFilepath(imageStruct); err != nil {
 		err = bh.BuildImage(*remoteBravefile)
 		if err != nil {
 			return fingerprint, err
@@ -567,7 +567,7 @@ func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *s
 		return "", err
 	}
 
-	path, err := getLocalImageFilepath(imageStruct)
+	path, err := queryLocalImageFilepath(imageStruct)
 	if err != nil {
 		return "", err
 	}
@@ -913,7 +913,7 @@ func getBuildDependents(dependency string, composeFile *shared.ComposeFile) (ser
 			return serviceNames, err
 		}
 
-		if _, err = getLocalImageFilepath(imageStruct); err == nil {
+		if _, err = queryLocalImageFilepath(imageStruct); err == nil {
 			continue
 		}
 		for _, dependsOn := range composeFile.Services[service].Depends {

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -216,11 +216,6 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 			return err
 		}
 
-		// Image architecture (if specified) must match base image architecture
-		if buildServerArch != img.Architecture {
-			return fmt.Errorf("base image arch %q is different from build server arch %q", img.Architecture, buildServerArch)
-		}
-
 		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, img.Size)
 		if err != nil {
 			return err
@@ -239,15 +234,6 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		imageFingerprint, err = importGitHub(ctx, lxdServer, bravefile, bh, bh.Remote.Profile, bh.Remote.Storage)
 		if err := shared.CollectErrors(err, ctx.Err()); err != nil {
 			return err
-		}
-
-		img, _, err := lxdServer.GetImage(imageFingerprint)
-		if err != nil {
-			return err
-		}
-
-		if buildServerArch != img.Architecture {
-			return fmt.Errorf("base image arch %q if different from build server architecture %q", img.Architecture, buildServerArch)
 		}
 
 		err = Start(lxdServer, bravefile.PlatformService.Name)
@@ -310,11 +296,6 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		img, err := GetImageByAlias(imageRemoteServer, bravefile.Base.Image)
 		if err != nil {
 			return err
-		}
-
-		// Since we spin up base container to build new one, must match build server arch
-		if buildServerArch != img.Architecture {
-			return fmt.Errorf("base image architecture %q does not match build server architecture %q", img.Architecture, buildServerArch)
 		}
 
 		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, img.Size)

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -160,11 +160,6 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		imageStruct.Version = defaultImageVersion
 	}
 
-	// Since we spin up base container to build new one, must match build server arch
-	if buildServerArch != imageStruct.Architecture {
-		return fmt.Errorf("image architecture %q does not match build server architecture %q", imageStruct.Architecture, buildServerArch)
-	}
-
 	// Intercept SIGINT, propagate cancel and cleanup artefacts
 	var imageFingerprint string
 
@@ -222,8 +217,8 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		}
 
 		// Image architecture (if specified) must match base image architecture
-		if imageStruct.Architecture != img.Architecture {
-			return fmt.Errorf("image architecture %q is different from base image arch %q", imageStruct.Architecture, img.Architecture)
+		if buildServerArch != img.Architecture {
+			return fmt.Errorf("base image arch %q is different from build server arch %q", img.Architecture, buildServerArch)
 		}
 
 		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, img.Size)
@@ -251,8 +246,8 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 			return err
 		}
 
-		if imageStruct.Architecture != img.Architecture {
-			return fmt.Errorf("image architecture %q is different from base image arch %q", imageStruct.Architecture, img.Architecture)
+		if buildServerArch != img.Architecture {
+			return fmt.Errorf("base image arch %q if different from build server architecture %q", img.Architecture, buildServerArch)
 		}
 
 		err = Start(lxdServer, bravefile.PlatformService.Name)
@@ -275,14 +270,6 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 				}
 			} else {
 				return err
-			}
-		}
-
-		// Since we spin up base container to build new one, must match build server arch
-		// Legacy local images do not store arch in filename, though - skipping
-		if localBaseImage.Architecture != "" {
-			if buildServerArch != localBaseImage.Architecture {
-				return fmt.Errorf("image architecture %q does not match build server architecture %q", imageStruct.Architecture, buildServerArch)
 			}
 		}
 
@@ -326,8 +313,8 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		}
 
 		// Since we spin up base container to build new one, must match build server arch
-		if imageStruct.Architecture != img.Architecture {
-			return fmt.Errorf("image architecture %q does not match build server architecture %q", imageStruct.Architecture, buildServerArch)
+		if buildServerArch != img.Architecture {
+			return fmt.Errorf("base image architecture %q does not match build server architecture %q", img.Architecture, buildServerArch)
 		}
 
 		err = CheckStoragePoolSpace(lxdServer, bh.Settings.StoragePool.Name, img.Size)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -95,6 +95,9 @@ func (bh *BraveHost) ImportLocalImage(sourcePath string) error {
 	if err != nil {
 		return err
 	}
+	if image.Name == "" {
+		return fmt.Errorf("tar file at %q does not provide an image name", sourcePath)
+	}
 
 	if _, err = queryLocalImageFilepath(image); err == nil {
 		return errors.New("image " + imageName + " already exists in local image store")

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -209,7 +209,8 @@ func (bh *BraveHost) DeleteLocalImage(name string) error {
 		return err
 	}
 	if _, err = queryLocalImageFilepath(image); err != nil {
-		if image, parseErr := ParseLegacyImageString(name); parseErr == nil {
+		var parseErr error
+		if image, parseErr = ParseLegacyImageString(name); parseErr == nil {
 			if _, legacyErr := queryLocalImageFilepath(image); legacyErr != nil {
 				return err
 			}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -99,7 +99,7 @@ func (bh *BraveHost) ImportLocalImage(sourcePath string) error {
 		return fmt.Errorf("tar file at %q does not provide an image name", sourcePath)
 	}
 
-	if _, err = queryLocalImageFilepath(image); err == nil {
+	if _, err = matchLocalImagePath(image); err == nil {
 		return errors.New("image " + imageName + " already exists in local image store")
 	}
 
@@ -172,7 +172,7 @@ func (bh *BraveHost) ListLocalImages() error {
 					timeUnit = "just now"
 				}
 
-				hashString, err := getImageHash(image)
+				hashString, err := hashImage(image)
 				if err != nil {
 					return err
 				}
@@ -208,17 +208,17 @@ func (bh *BraveHost) DeleteLocalImage(name string) error {
 	if err != nil {
 		return err
 	}
-	if _, err = queryLocalImageFilepath(image); err != nil {
+	if _, err = matchLocalImagePath(image); err != nil {
 		var parseErr error
 		if image, parseErr = ParseLegacyImageString(name); parseErr == nil {
-			if _, legacyErr := queryLocalImageFilepath(image); legacyErr != nil {
+			if _, legacyErr := matchLocalImagePath(image); legacyErr != nil {
 				return err
 			}
 		} else {
 			return err
 		}
 	}
-	imagePath, err := queryLocalImageFilepath(image)
+	imagePath, err := matchLocalImagePath(image)
 	if err != nil {
 		return err
 	}
@@ -905,7 +905,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		}
 	}
 
-	if _, err = queryLocalImageFilepath(imageStruct); err != nil {
+	if _, err = matchLocalImagePath(imageStruct); err != nil {
 		return err
 	}
 
@@ -956,7 +956,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		return err
 	}
 
-	image, err := queryLocalImageFilepath(imageStruct)
+	image, err := matchLocalImagePath(imageStruct)
 	if err != nil {
 		return err
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -96,14 +96,11 @@ func (bh *BraveHost) ImportLocalImage(sourcePath string) error {
 		return err
 	}
 
-	if imageExists(image) {
+	if _, err = getLocalImageFilepath(image); err == nil {
 		return errors.New("image " + imageName + " already exists in local image store")
 	}
 
 	imagePath := filepath.Join(imageStore, image.ToBasename()+".tar.gz")
-	if err != nil {
-		return err
-	}
 	hashFile := imagePath + ".md5"
 
 	err = shared.CopyFile(sourcePath, imagePath)
@@ -208,17 +205,16 @@ func (bh *BraveHost) DeleteLocalImage(name string) error {
 	if err != nil {
 		return err
 	}
-	if !imageExists(image) {
-		legacyImage, err := ParseLegacyImageString(name)
-		if err == nil {
-			if !imageExists(legacyImage) {
-				return fmt.Errorf("image %q does not exist", name)
+	if _, err = getLocalImageFilepath(image); err != nil {
+		if image, parseErr := ParseLegacyImageString(name); parseErr == nil {
+			if _, legacyErr := getLocalImageFilepath(image); legacyErr != nil {
+				return err
 			}
 		} else {
-			return fmt.Errorf("image %q does not exist", name)
+			return err
 		}
 	}
-	imagePath, err := getImageFilepath(image)
+	imagePath, err := getLocalImageFilepath(image)
 	if err != nil {
 		return err
 	}
@@ -707,7 +703,7 @@ func (e *ImageExistsError) Error() string {
 
 // BuildImage creates an image based on Bravefile
 func (bh *BraveHost) BuildImage(bravefile shared.Bravefile) error {
-	err := buildImage(bh, bravefile)
+	err := buildImage(bh, &bravefile)
 
 	switch err.(type) {
 	case nil:
@@ -742,14 +738,22 @@ func (bh *BraveHost) PublishUnit(unitName string, imageName string) error {
 		return err
 	}
 
+	serverArch, err := GetLXDServerArch(lxdServer)
+	if err != nil {
+		return errors.New("failed to determine LXD server CPU architecture")
+	}
+
 	if imageName == "" {
 		timestamp := time.Now()
-		imageName = unitName + "/" + timestamp.Format("20060102150405")
+		imageName = unitName + "/" + timestamp.Format("20060102150405") + "/" + serverArch
 	}
 
 	imageStruct, err := ParseImageString(imageName)
 	if err != nil {
 		return fmt.Errorf("failed to parse image string %q: %s", imageName, err)
+	}
+	if imageStruct.Architecture != serverArch {
+		return fmt.Errorf("provided image name %q specifies a different architecture than the LXD server (%q)", imageStruct.String(), serverArch)
 	}
 	imageName = imageStruct.ToBasename()
 
@@ -897,8 +901,8 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		}
 	}
 
-	if !imageExists(imageStruct) {
-		return fmt.Errorf("image %q does not exist", imageStruct.String())
+	if _, err = getLocalImageFilepath(imageStruct); err != nil {
+		return err
 	}
 
 	// Connect to deploy target remote
@@ -948,7 +952,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		return err
 	}
 
-	image, err := getImageFilepath(imageStruct)
+	image, err := getLocalImageFilepath(imageStruct)
 	if err != nil {
 		return err
 	}

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -96,7 +96,7 @@ func (bh *BraveHost) ImportLocalImage(sourcePath string) error {
 		return err
 	}
 
-	if _, err = getLocalImageFilepath(image); err == nil {
+	if _, err = queryLocalImageFilepath(image); err == nil {
 		return errors.New("image " + imageName + " already exists in local image store")
 	}
 
@@ -205,16 +205,16 @@ func (bh *BraveHost) DeleteLocalImage(name string) error {
 	if err != nil {
 		return err
 	}
-	if _, err = getLocalImageFilepath(image); err != nil {
+	if _, err = queryLocalImageFilepath(image); err != nil {
 		if image, parseErr := ParseLegacyImageString(name); parseErr == nil {
-			if _, legacyErr := getLocalImageFilepath(image); legacyErr != nil {
+			if _, legacyErr := queryLocalImageFilepath(image); legacyErr != nil {
 				return err
 			}
 		} else {
 			return err
 		}
 	}
-	imagePath, err := getLocalImageFilepath(image)
+	imagePath, err := queryLocalImageFilepath(image)
 	if err != nil {
 		return err
 	}
@@ -901,7 +901,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		}
 	}
 
-	if _, err = getLocalImageFilepath(imageStruct); err != nil {
+	if _, err = queryLocalImageFilepath(imageStruct); err != nil {
 		return err
 	}
 
@@ -952,7 +952,7 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		return err
 	}
 
-	image, err := getLocalImageFilepath(imageStruct)
+	image, err := queryLocalImageFilepath(imageStruct)
 	if err != nil {
 		return err
 	}

--- a/platform/images.go
+++ b/platform/images.go
@@ -116,13 +116,7 @@ func validImageFieldChar(char rune) bool {
 }
 
 func (imageStruct BravetoolsImage) ToBasename() string {
-	fields := []string{}
-	for _, field := range []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture} {
-		if field == "" {
-			break
-		}
-		fields = append(fields, field)
-	}
+	fields := []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture}
 	return strings.Join(fields, "_")
 }
 
@@ -140,9 +134,6 @@ func (imageStruct BravetoolsImage) String() string {
 func ImageFromFilename(filename string) (BravetoolsImage, error) {
 	filename = strings.TrimSuffix(filename, ".tar.gz")
 	split := strings.SplitN(filename, "_", 3)
-	// if len(split) > 3 {
-	// 	return BravetoolsImage{}, fmt.Errorf("filename %q does not conform to image format '<image_name>_<version>_<arch>", filename)
-	// }
 
 	image := BravetoolsImage{
 		Name:         split[0],
@@ -174,9 +165,18 @@ func getLocalImageFilepath(image BravetoolsImage) (string, error) {
 		return "", fmt.Errorf("failed to access bravetools image store: %s", err)
 	}
 
-	imagePath := filepath.Join(homeDir, shared.ImageStore, image.ToBasename())
+	var fileRegexArr []string
+	for _, field := range []string{image.Name, image.Version, image.Architecture} {
+		if field == "" {
+			fileRegexArr = append(fileRegexArr, "*")
+		} else {
+			fileRegexArr = append(fileRegexArr, field)
+		}
+	}
 
-	matches, err := filepath.Glob(imagePath + "*" + ".tar.gz")
+	imagePath := filepath.Join(homeDir, shared.ImageStore, strings.Join(fileRegexArr, "_")) + ".tar.gz"
+
+	matches, err := filepath.Glob(imagePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to search bravetools image store: %s", err)
 	}

--- a/platform/images.go
+++ b/platform/images.go
@@ -6,14 +6,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
+	"path/filepath"
 	"strings"
 	"unicode"
 
 	"github.com/bravetools/bravetools/shared"
 )
 
-const defaultImageVersion = "1.0"
+const defaultImageVersion = ""
 
 type BravetoolsImage struct {
 	Name         string
@@ -26,22 +26,21 @@ func ParseImageString(imageString string) (imageStruct BravetoolsImage, err erro
 	_, imageString = ParseRemoteName(imageString)
 
 	// Image schema: image/version/arch
-	split := strings.SplitN(imageString, "/", 4)
+	split := strings.SplitN(imageString, "/", 3)
 
-	if len(split) > 4 {
-		return imageStruct, fmt.Errorf("unrecongized format - bravetools image schema is remote:<image_name>[/version/arch]")
-	}
+	// if len(split) > 4 {
+	// 	return imageStruct, fmt.Errorf("unrecongized format - bravetools image schema is remote:<image_name>[/version/arch]")
+	// }
 
 	if split[0] == "" {
 		return imageStruct, fmt.Errorf("image name not provided in %q - bravetools image schema is remote:<image_name>[/version/arch]", imageString)
 	}
 
 	// Default struct
-	// Architecture defaults to runtime arch
 	imageStruct = BravetoolsImage{
 		Name:         split[0],
 		Version:      defaultImageVersion,
-		Architecture: runtime.GOARCH,
+		Architecture: "",
 	}
 
 	// Override defaults if provided
@@ -74,11 +73,10 @@ func ParseLegacyImageString(imageString string) (imageStruct BravetoolsImage, er
 	}
 
 	// Default struct
-	// Architecture defaults to runtime arch
 	imageStruct = BravetoolsImage{
 		Name:         strings.Join(split[:len(split)-1], "-"),
 		Version:      split[len(split)-1],
-		Architecture: runtime.GOARCH,
+		Architecture: "",
 	}
 
 	if !validImageName(imageStruct) {
@@ -100,7 +98,8 @@ func validImageName(imageStruct BravetoolsImage) bool {
 		}
 	}
 	for _, char := range imageStruct.Architecture {
-		if !validImageFieldChar(char) {
+		// Underscore allowed for arch - special case
+		if !validImageFieldChar(char) && char != '_' {
 			return false
 		}
 	}
@@ -117,26 +116,38 @@ func validImageFieldChar(char rune) bool {
 }
 
 func (imageStruct BravetoolsImage) ToBasename() string {
-	fields := []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture}
+	fields := []string{}
+	for _, field := range []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture} {
+		if field == "" {
+			break
+		}
+		fields = append(fields, field)
+	}
 	return strings.Join(fields, "_")
 }
 
 func (imageStruct BravetoolsImage) String() string {
-	fields := []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture}
+	fields := []string{}
+	for _, field := range []string{imageStruct.Name, imageStruct.Version, imageStruct.Architecture} {
+		if field == "" {
+			break
+		}
+		fields = append(fields, field)
+	}
 	return strings.Join(fields, "/")
 }
 
 func ImageFromFilename(filename string) (BravetoolsImage, error) {
 	filename = strings.TrimSuffix(filename, ".tar.gz")
-	split := strings.Split(filename, "_")
-	if len(split) > 3 {
-		return BravetoolsImage{}, fmt.Errorf("filename %q does not conform to image format '<image_name>_<version>_<arch>", filename)
-	}
+	split := strings.SplitN(filename, "_", 3)
+	// if len(split) > 3 {
+	// 	return BravetoolsImage{}, fmt.Errorf("filename %q does not conform to image format '<image_name>_<version>_<arch>", filename)
+	// }
 
 	image := BravetoolsImage{
 		Name:         split[0],
 		Version:      defaultImageVersion,
-		Architecture: runtime.GOARCH,
+		Architecture: "",
 	}
 
 	if len(split) > 1 {
@@ -157,27 +168,48 @@ func ImageFromFilename(filename string) (BravetoolsImage, error) {
 	return image, nil
 }
 
-func imageExists(image BravetoolsImage) bool {
-	_, err := getImageFilepath(image)
-	return err == nil
-}
-
-func getImageFilepath(image BravetoolsImage) (string, error) {
-	homeDir, _ := os.UserHomeDir()
-	imagePath := path.Join(homeDir, shared.ImageStore, image.ToBasename()+".tar.gz")
-	if shared.FileExists(imagePath) {
-		return imagePath, nil
+func getLocalImageFilepath(image BravetoolsImage) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to access bravetools image store: %s", err)
 	}
-	// Legacy filenames will not have arch
+
+	imagePath := filepath.Join(homeDir, shared.ImageStore, image.ToBasename())
+
+	matches, err := filepath.Glob(imagePath + "*" + ".tar.gz")
+	if err != nil {
+		return "", fmt.Errorf("failed to search bravetools image store: %s", err)
+	}
+
+	nmatches := len(matches)
+	switch {
+	case nmatches == 1:
+		return matches[0], nil
+	case nmatches > 1:
+		// Multiple matches - ambiguous result. Return formatted error with the options.
+		imageStrings := make([]string, nmatches)
+		for _, path := range matches {
+			img, err := ImageFromFilename(filepath.Base(path))
+			if err != nil {
+				imageStrings = append(imageStrings, path)
+			} else {
+				imageStrings = append(imageStrings, img.String())
+			}
+		}
+		return "", fmt.Errorf("multiple matches for image %q in image store - specify version and/or architecture.\nMatches:%s", image, strings.Join(imageStrings, "\n"))
+	}
+
+	// If no matches, attempt to find legacy file: legacy filenames will not have arch
 	imagePath = path.Join(homeDir, shared.ImageStore, image.Name+"-"+image.Version+".tar.gz")
 	if shared.FileExists(imagePath) {
 		return imagePath, nil
 	}
 	return "", fmt.Errorf("failed to retrieve path for image %s, version %s, arch %s ", image.Name, image.Version, image.Architecture)
+
 }
 
 func getImageHash(image BravetoolsImage) (string, error) {
-	localImageFile, err := getImageFilepath(image)
+	localImageFile, err := getLocalImageFilepath(image)
 	if err != nil {
 		return "", err
 	}
@@ -218,7 +250,7 @@ func getImageHash(image BravetoolsImage) (string, error) {
 }
 
 func localImageSize(image BravetoolsImage) (bytes int64, err error) {
-	imagePath, err := getImageFilepath(image)
+	imagePath, err := getLocalImageFilepath(image)
 	if err != nil {
 		return bytes, err
 	}
@@ -247,7 +279,7 @@ func resolveBaseImageLocation(imageString string) (location string, err error) {
 		return "", err
 	}
 
-	if imageExists(imageStruct) {
+	if _, err = getLocalImageFilepath(imageStruct); err == nil {
 		return "local", nil
 	}
 
@@ -264,7 +296,7 @@ func resolveBaseImageLocation(imageString string) (location string, err error) {
 	// Check for legacy image field
 	imageStruct, err = ParseLegacyImageString(imageString)
 	if err == nil {
-		if imageExists(imageStruct) {
+		if _, err = getLocalImageFilepath(imageStruct); err == nil {
 			return "local", nil
 		}
 	}

--- a/platform/images.go
+++ b/platform/images.go
@@ -152,8 +152,10 @@ func ImageFromFilename(filename string) (BravetoolsImage, error) {
 	// Final "-" is followed by version - no arch
 	if len(split) == 1 {
 		split = strings.Split(filename, "-")
-		image.Name = strings.Join(split[:len(split)-1], "-")
-		image.Version = split[len(split)-1]
+		if len(split) > 1 {
+			image.Name = strings.Join(split[:len(split)-1], "-")
+			image.Version = split[len(split)-1]
+		}
 	}
 
 	return image, nil

--- a/platform/images_test.go
+++ b/platform/images_test.go
@@ -56,18 +56,20 @@ func TestImageFromFilename(t *testing.T) {
 }
 
 func TestImageFromFilenameLong(t *testing.T) {
-	name := "alpine_3.16_amd64_test.tar.gz"
+	archWithUnderscore := "_amd64_TEST"
+	name := "alpine_3.16_amd64" + archWithUnderscore + ".tar.gz"
 	_, err := ImageFromFilename(name)
-	if err == nil {
-		t.Fatalf("expected err when parsing image from filename %q", name)
+	if err != nil {
+		t.Fatalf("error when parsing image from filename %q with an underscore in architecture field", name)
 	}
 }
 
 func TestImageFromFilenameShort(t *testing.T) {
-	name := "alpine_3.16_amd64_test.tar.gz"
+	archWithUnderscore := "_amd64_TEST"
+	name := "alpine_3.16" + archWithUnderscore + ".tar.gz"
 	_, err := ImageFromFilename(name)
-	if err == nil {
-		t.Fatalf("expected err when parsing image from filename %q", name)
+	if err != nil {
+		t.Fatalf("error when parsing image from filename %q with an underscore in architecture field", name)
 	}
 }
 
@@ -90,9 +92,10 @@ func TestImageFromFilenameLegacy(t *testing.T) {
 }
 
 func TestImageFromFilenameIncorrectLong(t *testing.T) {
-	name := "python-auth-1.0_1.0_amd64_TEST.tar.gz"
+	archWithUnderscore := "_amd64_TEST"
+	name := "python-auth-1.0_1.0" + archWithUnderscore + ".tar.gz"
 	_, err := ImageFromFilename(name)
-	if err == nil {
-		t.Fatalf("expected err when parsing image from filename %q", name)
+	if err != nil {
+		t.Fatalf("error when parsing image from filename %q with an underscore in architecture field", name)
 	}
 }

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -1510,3 +1510,12 @@ func GetLXDServerVersion(lxdServer lxd.InstanceServer) (int, error) {
 
 	return strconv.Atoi(serverVersionString)
 }
+
+func GetLXDServerArch(lxdServer lxd.InstanceServer) (string, error) {
+	serverStatus, _, err := lxdServer.GetServer()
+	if err != nil {
+		return "", err
+	}
+
+	return serverStatus.Environment.KernelArchitecture, nil
+}


### PR DESCRIPTION
## Image architectures
This PR changes the way bravetools stores image architectures to align with the architectures reported by the build LXD server. This  also addresses issues caused when using a remote build server that is a different architecture than the bravetools host.

Prior to this change, image architectures would be dervied from the runtime.GOARCH. For example: amd64/arm64.

After this change the LXD server reported value will be used. For example: x86_64/armv6l.

## Image version "untagged" by default
Previously bravetools used version "1.0" as a default, but this was arbitrary and could be confusing if the user actually specified 1.0 themselves. The "untagged" version makes it clearer that it is not user-provided and avoids potential conflicts.

## Image matching
This PR also adds image matching where partially defined images will be matched in certain cases. This allows the user to specify images via shorthand by excluding the version/architecture field. So long as only one possible image matches the image description the image will be matched. In cases where there are multiple possible matching images an error will be raised.

For example:
```bash
brave images

IMAGE                       VERSION         ARCH    CREATED         SIZE    HASH
python                      1.0             x86_64  4 days ago      3MB     d74509498411e8aca47573f9984568af

brave remove -i python   // Works - python/1.0 will be removed

...  // Adding new images

brave images

IMAGE                           VERSION         ARCH    CREATED         SIZE    HASH
python-api                      1.0             x86_64  4 days ago      3MB     baa79a888963493466be56636a33e3fd
python-api                      untagged        x86_64  4 days ago      3MB     9cec55982dbcfea4dc30e8e344610f13

brave remove -i python-api   // Fails, matches multiple images
2022/11/18 16:08:05 multiple matches for image "python-api" in image store - specify version and/or architecture.
Matches:

python-api/1.0/x86_64
python-api/untagged/x86_64
```