### PR TITLE
Accurate architectures

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -558,7 +558,21 @@ func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *s
 
 	path, err := matchLocalImagePath(imageStruct)
 	if err != nil {
-		return "", err
+		if errors.As(err, &multipleImageMatches{}) {
+			return "", err
+		}
+
+		var legacyParseErr error
+		var legacyMatchErr error
+		imageStruct, legacyParseErr = ParseLegacyImageString(bravefile.Base.Image)
+		if legacyParseErr != nil {
+			return "", err
+		}
+
+		path, legacyMatchErr = matchLocalImagePath(imageStruct)
+		if legacyMatchErr != nil {
+			return "", err
+		}
 	}
 
 	fingerprint, err = shared.FileSha256Hash(path)

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -247,6 +247,11 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 			return err
 		}
 		if _, err = matchLocalImagePath(localBaseImage); err != nil {
+			// In case of multiple possible matches ask user to specify rather than proceed to legacy image parsing
+			if errors.As(err, &multipleImageMatches{}) {
+				return err
+			}
+
 			// Check legacy bravefile
 			var parseErr error
 			localBaseImage, parseErr = ParseLegacyImageString(bravefile.Base.Image)

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -208,16 +208,6 @@ func (bh *BraveHost) DeleteLocalImage(name string) error {
 	if err != nil {
 		return err
 	}
-	if _, err = matchLocalImagePath(image); err != nil {
-		var parseErr error
-		if image, parseErr = ParseLegacyImageString(name); parseErr == nil {
-			if _, legacyErr := matchLocalImagePath(image); legacyErr != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
 	imagePath, err := matchLocalImagePath(image)
 	if err != nil {
 		return err


### PR DESCRIPTION
Small fixes surrounding legacy image name support.

Remove legacy parsing entirely for `brave remove -i <image_name>` CLI command due to possibility of removing the wrong image if the names/versions line up in a certain way - updating to the modern syntax should not be hard since it is a CLI command.

Return multipleImageMatches to provide reason for image match failure - this allows calling code to react based on whether image match failed due to multiple candidates or due to no candidates being found. If multiple cands, avoid attempting legacy image parsing.