### PR TITLE
Optional legacy image filename

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -100,7 +100,7 @@ func (bh *BraveHost) ImportLocalImage(sourcePath string) error {
 	}
 
 	if _, err = matchLocalImagePath(image); err == nil {
-		return errors.New("image " + imageName + " already exists in local image store")
+		return fmt.Errorf("image %q already exists in local image store", image)
 	}
 
 	imagePath := filepath.Join(imageStore, image.ToBasename()+".tar.gz")
@@ -116,8 +116,6 @@ func (bh *BraveHost) ImportLocalImage(sourcePath string) error {
 		return errors.New("failed to generate image hash: " + err.Error())
 	}
 
-	fmt.Println(imageHash)
-
 	// Write image hash to a file
 	f, err := os.Create(hashFile)
 	if err != nil {
@@ -129,6 +127,8 @@ func (bh *BraveHost) ImportLocalImage(sourcePath string) error {
 	if err != nil {
 		return errors.New(err.Error())
 	}
+
+	fmt.Printf("Imported file %q into bravetools as image %q\n", imageName, image)
 
 	return nil
 }

--- a/platform/images.go
+++ b/platform/images.go
@@ -82,6 +82,11 @@ func ParseLegacyImageString(imageString string) (imageStruct BravetoolsImage, er
 	return imageStruct, nil
 }
 func validImageName(imageStruct BravetoolsImage) bool {
+	// Cannot have empty name
+	if imageStruct.Name == "" {
+		return false
+	}
+
 	// Check Name, Version and Architecture fields for non-allowed characters
 	for _, char := range imageStruct.Name {
 		if !validImageFieldChar(char) {
@@ -144,8 +149,8 @@ func ImageFromFilename(filename string) (BravetoolsImage, error) {
 		image.Architecture = split[2]
 	}
 
-	if image.Name == "" {
-		return image, fmt.Errorf("filename %q is not parsable as a bravetools image", filename)
+	if !validImageName(image) {
+		return image, fmt.Errorf("image %q is not a valid image description", image)
 	}
 
 	return image, nil
@@ -168,8 +173,8 @@ func ImageFromLegacyFilename(filename string) (BravetoolsImage, error) {
 		image.Version = split[len(split)-1]
 	}
 
-	if image.Name == "" {
-		return image, fmt.Errorf("filename %q is not parsable as a legacy bravetools image", filename)
+	if !validImageName(image) {
+		return image, fmt.Errorf("image %q is not a valid image description", image)
 	}
 
 	return image, nil

--- a/platform/images.go
+++ b/platform/images.go
@@ -48,8 +48,8 @@ func ParseImageString(imageString string) (imageStruct BravetoolsImage, err erro
 		imageStruct.Version = split[1]
 	}
 
-	if !validImageName(imageStruct) {
-		return imageStruct, fmt.Errorf("image %q is not a valid string - fields must not contain special characters", imageString)
+	if err := validateImage(imageStruct); err != nil {
+		return imageStruct, fmt.Errorf("image %q is not a valid string: %s", imageString, err)
 	}
 
 	return imageStruct, nil
@@ -75,37 +75,37 @@ func ParseLegacyImageString(imageString string) (imageStruct BravetoolsImage, er
 		Architecture: "",
 	}
 
-	if !validImageName(imageStruct) {
-		return imageStruct, fmt.Errorf("image %q is not a valid string - fields must not contain special characters", imageString)
+	if err := validateImage(imageStruct); err != nil {
+		return imageStruct, fmt.Errorf("image %q is not a valid string: %s", imageString, err)
 	}
 
 	return imageStruct, nil
 }
-func validImageName(imageStruct BravetoolsImage) bool {
+func validateImage(imageStruct BravetoolsImage) error {
 	// Cannot have empty name
 	if imageStruct.Name == "" {
-		return false
+		return errors.New("image cannot have an empty name")
 	}
 
 	// Check Name, Version and Architecture fields for non-allowed characters
 	for _, char := range imageStruct.Name {
 		if !validImageFieldChar(char) {
-			return false
+			return fmt.Errorf("character %q is not valid in image name field", char)
 		}
 	}
 	for _, char := range imageStruct.Version {
 		if !validImageFieldChar(char) {
-			return false
+			return fmt.Errorf("character %q is not valid in image version field", char)
 		}
 	}
 	for _, char := range imageStruct.Architecture {
 		// Underscore allowed for arch - special case
 		if !validImageFieldChar(char) && char != '_' {
-			return false
+			return fmt.Errorf("character %q is not valid in image architecture field", char)
 		}
 	}
 
-	return true
+	return nil
 }
 
 func validImageFieldChar(char rune) bool {
@@ -149,8 +149,8 @@ func ImageFromFilename(filename string) (BravetoolsImage, error) {
 		image.Architecture = split[2]
 	}
 
-	if !validImageName(image) {
-		return image, fmt.Errorf("image %q is not a valid image description", image)
+	if err := validateImage(image); err != nil {
+		return image, fmt.Errorf("image %q is not a valid string: %s", image, err)
 	}
 
 	return image, nil
@@ -173,8 +173,8 @@ func ImageFromLegacyFilename(filename string) (BravetoolsImage, error) {
 		image.Version = split[len(split)-1]
 	}
 
-	if !validImageName(image) {
-		return image, fmt.Errorf("image %q is not a valid image description", image)
+	if err := validateImage(image); err != nil {
+		return image, fmt.Errorf("image %q is not a valid string: %s", image, err)
 	}
 
 	return image, nil

--- a/platform/images.go
+++ b/platform/images.go
@@ -144,14 +144,32 @@ func ImageFromFilename(filename string) (BravetoolsImage, error) {
 		image.Architecture = split[2]
 	}
 
+	if image.Name == "" {
+		return image, fmt.Errorf("filename %q is not parsable as a bravetools image", filename)
+	}
+
+	return image, nil
+}
+
+func ImageFromLegacyFilename(filename string) (BravetoolsImage, error) {
 	// Legacy filenames are not delimited by underscores
 	// Final "-" is followed by version - no arch
-	if len(split) == 1 {
-		split = strings.Split(filename, "-")
-		if len(split) > 1 {
-			image.Name = strings.Join(split[:len(split)-1], "-")
-			image.Version = split[len(split)-1]
-		}
+	filename = strings.TrimSuffix(filename, ".tar.gz")
+	split := strings.Split(filename, "-")
+
+	image := BravetoolsImage{
+		Name:         split[0],
+		Version:      defaultImageVersion,
+		Architecture: "",
+	}
+
+	if len(split) > 1 {
+		image.Name = strings.Join(split[:len(split)-1], "-")
+		image.Version = split[len(split)-1]
+	}
+
+	if image.Name == "" {
+		return image, fmt.Errorf("filename %q is not parsable as a legacy bravetools image", filename)
 	}
 
 	return image, nil

--- a/platform/images_test.go
+++ b/platform/images_test.go
@@ -99,3 +99,19 @@ func TestImageFromFilenameIncorrectLong(t *testing.T) {
 		t.Fatalf("error when parsing image from filename %q with an underscore in architecture field", name)
 	}
 }
+
+func TestImageFilenameHypen(t *testing.T) {
+	name := "_" + ".tar.gz"
+	_, err := ImageFromFilename(name)
+	if err == nil {
+		t.Fatalf("error expected when parsing image from filename %q", name)
+	}
+}
+
+func TestLegacyImageFilenameHypen(t *testing.T) {
+	name := "-" + ".tar.gz"
+	_, err := ImageFromLegacyFilename(name)
+	if err == nil {
+		t.Fatalf("error when parsing image from filename %q", name)
+	}
+}


### PR DESCRIPTION
Legacy image filename parsing was not optional when calling `ImageFromFilename`. This could lead to problems with incorrectly parsing names with hyphens as versions. Legacy parsing should be opt in and used only in places it makes sense.

Command line commands will now default to modern image syntax. Legacy parsing reserved only for listing images in the bravetools image store.

Also included in this PR are better validation of names and improved error messaging.