### PR TITLE
Infer local base image arch

### DIFF
--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -272,6 +272,9 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 		if err != nil {
 			return err
 		}
+		if localBaseImage.Architecture == "" {
+			localBaseImage.Architecture = buildServerArch
+		}
 		if _, err = matchLocalImagePath(localBaseImage); err != nil {
 			// In case of multiple possible matches ask user to specify rather than proceed to legacy image parsing
 			if errors.As(err, &multipleImageMatches{}) {
@@ -527,6 +530,12 @@ func importLocal(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *s
 	imageStruct, err = ParseImageString(bravefile.Base.Image)
 	if err != nil {
 		return "", err
+	}
+	if imageStruct.Architecture == "" {
+		imageStruct.Architecture, err = GetLXDServerArch(lxdServer)
+		if err != nil {
+			return "", fmt.Errorf("failed to get lxd build server arch: %s", err)
+		}
 	}
 
 	path, err := matchLocalImagePath(imageStruct)

--- a/platform/images.go
+++ b/platform/images.go
@@ -330,6 +330,9 @@ func resolveBaseImageLocation(imageString string, architecture string) (location
 	if err != nil {
 		return "", err
 	}
+	if imageStruct.Architecture == "" {
+		imageStruct.Architecture = architecture
+	}
 
 	if _, err = matchLocalImagePath(imageStruct); err == nil {
 		return "local", nil


### PR DESCRIPTION
Using build server arch to infer required local base image architecture. Resolves issues when multiple arches exist for a given local image.

Closes https://github.com/bravetools/bravetools/issues/205