### PR TITLE
Handling cleanup of legacy images on err

### DIFF
--- a/commands/remove.go
+++ b/commands/remove.go
@@ -31,7 +31,7 @@ func remove(cmd *cobra.Command, args []string) {
 
 	for _, arg := range args {
 		if imageToggle {
-			err := host.DeleteLocalImage(arg)
+			err := host.DeleteLocalImage(arg, false)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -133,7 +133,7 @@ func buildImage(bh *BraveHost, bravefile *shared.Bravefile) error {
 	}
 
 	// If version explicitly provided separately this is a legacy Bravefile
-	if bravefile.PlatformService.Version == "" || bravefile.Image != "" {
+	if !bravefile.IsLegacy() {
 		imageStruct, err = ParseImageString(imageString)
 	} else {
 		imageStruct, err = ParseLegacyImageString(imageString)
@@ -402,7 +402,7 @@ func TransferImage(sourceRemote Remote, bravefile shared.Bravefile) error {
 	}
 
 	// If version explicitly provided separately this is a legacy Bravefile
-	if bravefile.PlatformService.Version == "" || bravefile.Image != "" {
+	if !bravefile.IsLegacy() {
 		imageStruct, err = ParseImageString(imageString)
 	} else {
 		imageStruct, err = ParseLegacyImageString(imageString)
@@ -491,7 +491,7 @@ func importGitHub(ctx context.Context, lxdServer lxd.InstanceServer, bravefile *
 	var imageStruct BravetoolsImage
 
 	// If version explicitly provided separately this is a legacy Bravefile
-	if remoteBravefile.PlatformService.Version == "" {
+	if remoteBravefile.PlatformService.IsLegacy() {
 		imageStruct, err = ParseImageString(remoteBravefile.PlatformService.Image)
 	} else {
 		imageStruct, err = ParseLegacyImageString(remoteBravefile.PlatformService.Image)
@@ -880,7 +880,7 @@ func getBuildDependents(dependency string, composeFile *shared.ComposeFile) (ser
 		var imageStruct BravetoolsImage
 
 		// If version explicitly provided separately this is a legacy Bravefile
-		if composeFile.Services[service].Version == "" {
+		if composeFile.Services[service].IsLegacy() {
 			imageStruct, err = ParseImageString(composeFile.Services[service].Image)
 		} else {
 			imageStruct, err = ParseLegacyImageString(composeFile.Services[service].Image)

--- a/platform/host_api_test.go
+++ b/platform/host_api_test.go
@@ -25,7 +25,7 @@ func Test_DeleteLocalImage(t *testing.T) {
 		t.Error("host.BuildImage: ", err)
 	}
 
-	err = host.DeleteLocalImage(imageName)
+	err = host.DeleteLocalImage(imageName, false)
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}
@@ -72,7 +72,7 @@ func Test_BuildImage(t *testing.T) {
 		t.Error("host.BuildImage: ", err)
 	}
 
-	err = host.DeleteLocalImage(bravefile.PlatformService.Image)
+	err = host.DeleteLocalImage(bravefile.PlatformService.Image, true)
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}
@@ -121,7 +121,7 @@ func Test_InitUnit(t *testing.T) {
 		t.Error("host.InitUnit: ", err)
 	}
 
-	err = host.DeleteLocalImage(bravefile.PlatformService.Image)
+	err = host.DeleteLocalImage(bravefile.PlatformService.Image, true)
 	if err != nil {
 		t.Error("host.DeleteImageByName: ", err)
 	}
@@ -207,7 +207,7 @@ func Test_Compose(t *testing.T) {
 			t.Errorf("failed to delete unit: %q", service.Name)
 			t.Log(err)
 		}
-		err = host.DeleteLocalImage(service.Image)
+		err = host.DeleteLocalImage(service.Image, true)
 		if err != nil {
 			t.Errorf("failed to delete unit: %q", service.Image)
 			t.Log(err)

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -134,6 +134,22 @@ func (bravefile *Bravefile) ValidateBuild() error {
 	return nil
 }
 
+func (bravefile *Bravefile) IsLegacy() bool {
+	if bravefile.PlatformService.Version == "" || bravefile.Image != "" {
+		return false
+	}
+
+	return true
+}
+
+func (service *Service) IsLegacy() bool {
+	if service.Version == "" {
+		return false
+	}
+
+	return true
+}
+
 func (service *Service) ValidateDeploy() error {
 	if service.Name == "" {
 		return errors.New("invalid Service: empty Service Name")


### PR DESCRIPTION
Required for cleanup of correct image if error occurs during build