### PR TITLE
Early failure if incorrect port forwarding syntax 

### DIFF
--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -163,6 +163,15 @@ func (service *Service) ValidateDeploy() error {
 		return errors.New("unit names should not contain special characters")
 	}
 
+	if len(service.Ports) > 0 {
+		for _, p := range service.Ports {
+			ps := strings.Split(p, ":")
+			if len(ps) < 2 || len(ps) > 2 || ps[1] == "" {
+				return fmt.Errorf("invalid port forwarding definition %q. Appropriate format is UNIT_PORT:HOST_PORT", p)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/shared/bravefile_test.go
+++ b/shared/bravefile_test.go
@@ -1,0 +1,30 @@
+package shared
+
+import "testing"
+
+func TestValidateDeployPorts(t *testing.T) {
+	service := Service{Name: "test-container", Image: "test-image", Ports: []string{"3000"}}
+	if err := service.ValidateDeploy(); err == nil {
+		t.Errorf("Expected port forwarding %q to fail", service.Ports)
+	}
+
+	service.Ports = []string{"3000:3000:3000"}
+	if err := service.ValidateDeploy(); err == nil {
+		t.Errorf("Expected port forwarding %q to fail", service.Ports)
+	}
+
+	service.Ports = []string{"3000:"}
+	if err := service.ValidateDeploy(); err == nil {
+		t.Errorf("Expected port forwarding %q to fail", service.Ports)
+	}
+
+	service.Ports = []string{"3000:3000"}
+	if err := service.ValidateDeploy(); err != nil {
+		t.Errorf("Expected port forwarding %q to succeed", service.Ports)
+	}
+
+	service.Ports = []string{}
+	if err := service.ValidateDeploy(); err != nil {
+		t.Errorf("Expected empty port forwarding %q to succeed", service.Ports)
+	}
+}


### PR DESCRIPTION
Added check to port forwarding syntax to `service.ValidateDeploy`. Add tests ensuring this behaviour.

Closes https://github.com/bravetools/bravetools/issues/222