### PR TITLE
Port forwarding syntax edge case

### DIFF
--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -166,7 +166,7 @@ func (service *Service) ValidateDeploy() error {
 	if len(service.Ports) > 0 {
 		for _, p := range service.Ports {
 			ps := strings.Split(p, ":")
-			if len(ps) < 2 || len(ps) > 2 || ps[1] == "" {
+			if len(ps) < 2 || len(ps) > 2 || ps[0] == "" || ps[1] == "" {
 				return fmt.Errorf("invalid port forwarding definition %q. Appropriate format is UNIT_PORT:HOST_PORT", p)
 			}
 		}

--- a/shared/bravefile_test.go
+++ b/shared/bravefile_test.go
@@ -18,6 +18,11 @@ func TestValidateDeployPorts(t *testing.T) {
 		t.Errorf("Expected port forwarding %q to fail", service.Ports)
 	}
 
+	service.Ports = []string{":3000"}
+	if err := service.ValidateDeploy(); err == nil {
+		t.Errorf("Expected port forwarding %q to fail", service.Ports)
+	}
+
 	service.Ports = []string{"3000:3000"}
 	if err := service.ValidateDeploy(); err != nil {
 		t.Errorf("Expected port forwarding %q to succeed", service.Ports)


### PR DESCRIPTION
Handle case where requested port forwarding begins with a colon - test added to cover this 