### PR TITLE
Name multipass VM "bravetools" instead of username

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -78,7 +78,6 @@ func serverInit(cmd *cobra.Command, args []string) {
 	}
 
 	if hostConfigPath != "" {
-		// TODO: validate configuration. Now assume that path ends with config.yml
 		err = shared.CopyFile(hostConfigPath, path.Join(userHome, shared.PlatformConfig))
 		if err != nil {
 			if err := deleteBraveHome(userHome); err != nil {

--- a/docs/docs/cli/brave_init.md
+++ b/docs/docs/cli/brave_init.md
@@ -31,8 +31,8 @@ On Mac and Windows platforms:
 On Linux distributions:
 
 * Set up a new LXD profile `$USER`
-* Create a new LXD bridge `$USERbr0`
-* Create a new storage pool `$USER-TIMESTAMP`
+* Create a new LXD bridge `bravetoolsbr0`
+* Create a new storage pool `$USER`
 
 These steps ensure that Bravetools establishes a connection with LXD server and runs a self-contained LXD environment that doesn't interfere with any potentially existing profiles and LXD bridges.
 

--- a/docs/docs/cli/brave_init.md
+++ b/docs/docs/cli/brave_init.md
@@ -30,9 +30,9 @@ On Mac and Windows platforms:
 
 On Linux distributions:
 
-* Set up a new LXD profile `$USER`
+* Set up a new LXD profile `bravetools-$USER`
 * Create a new LXD bridge `bravetoolsbr0`
-* Create a new storage pool `$USER`
+* Create a new storage pool `bravetools-$USER`
 
 These steps ensure that Bravetools establishes a connection with LXD server and runs a self-contained LXD environment that doesn't interfere with any potentially existing profiles and LXD bridges.
 

--- a/docs/docs/init.md
+++ b/docs/docs/init.md
@@ -28,8 +28,8 @@ brave init
 This will create:
 
 * Network bridge - bravetoolsbr0, randomly-assigned private IP from a range of available IP values.
-* Storage device - ${USER}, ZFS file system
-* User profile - ${USER}
+* Storage device - bravetools-${USER}, ZFS file system
+* User profile - bravetools-${USER}
 * Remotes - local
 
 # Configuring Bravetools using a `yaml` file

--- a/docs/docs/init.md
+++ b/docs/docs/init.md
@@ -27,8 +27,8 @@ brave init
 
 This will create:
 
-* Network bridge - ${USER}br0, randomly-assigned private IP from a range of available IP values.
-* Storage device - ${USER}${TIMESTAMP}, ZFS file system
+* Network bridge - bravetoolsbr0, randomly-assigned private IP from a range of available IP values.
+* Storage device - ${USER}, ZFS file system
 * User profile - ${USER}
 * Remotes - local
 

--- a/docs/installation/uninstall-bravetools.md
+++ b/docs/installation/uninstall-bravetools.md
@@ -9,7 +9,7 @@ description: "Instructions to uninstall Bravetools"
 # Uninstall Bravetools on MacOS/Windows with Multipass host
 
 ```bash
-multipass delete $USER; multipass purge
+multipass delete bravetools; multipass purge
 rm -r ~/.bravetools
 ```
 
@@ -18,8 +18,8 @@ Artefacts created by Bravetools can be uninstalled using LXD:
 
 ```bash
 lxc profile delete $USER
-lxc storage delete $USER-[TIMESTAMP] # You will need to get specific storage name using lxc storage list
-lxc network delete $USER"br0"
+lxc storage delete $USER
+lxc network delete bravetoolsbr0
 ```
 
 Finally, remove Bravetools images, databases, and certificates:

--- a/docs/installation/uninstall-bravetools.md
+++ b/docs/installation/uninstall-bravetools.md
@@ -17,8 +17,8 @@ rm -r ~/.bravetools
 Artefacts created by Bravetools can be uninstalled using LXD:
 
 ```bash
-lxc profile delete $USER
-lxc storage delete $USER
+lxc profile delete bravetools-$USER
+lxc storage delete bravetools-$USER
 lxc network delete bravetoolsbr0
 ```
 

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -11,7 +11,6 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"syscall"
 
@@ -29,21 +28,7 @@ func getCurrentUsername() (username string, err error) {
 		return "", err
 	}
 
-	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
-	if err != nil {
-		return "", err
-	}
-
-	username = reg.ReplaceAllString(user.Username, "")
-
-	// Truncate to max username length if necessary
-	usernameLength := 12
-	if len(username) < usernameLength {
-		usernameLength = len(username)
-	}
-	username = username[:usernameLength]
-
-	return username, nil
+	return user.Username, nil
 }
 
 // createSharedVolume creates a volume in storage pool and mounts it to both source unit and target unit

--- a/platform/helpers.go
+++ b/platform/helpers.go
@@ -28,7 +28,7 @@ func getCurrentUsername() (username string, err error) {
 		return "", err
 	}
 
-	return user.Username, nil
+	return "bravetools-" + user.Username, nil
 }
 
 // createSharedVolume creates a volume in storage pool and mounts it to both source unit and target unit

--- a/platform/host.go
+++ b/platform/host.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"time"
 
 	"github.com/bravetools/bravetools/shared"
 	"gopkg.in/yaml.v2"
@@ -100,20 +99,20 @@ func SetupHostConfiguration(params HostConfig, userHome string) (settings HostSe
 	poolSizeInt, _ := strconv.Atoi(params.Storage)
 	poolSizeInt = poolSizeInt - 2
 
-	hostName, err := getCurrentUsername()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	hostName := shared.BravetoolsVmName
 
-	timestamp := time.Now()
-	storagePoolName := hostName + "-" + timestamp.Format("20060102150405")
+	profileName, err := getCurrentUsername()
+	if err != nil {
+		log.Fatal(err)
+	}
+	storagePoolName := profileName
 
 	networkBridgeName := hostName + "br0"
 
 	settings = HostSettings{
 		Name:    hostName,
 		Trust:   hostName,
-		Profile: hostName,
+		Profile: profileName,
 		StoragePool: Storage{
 			Type: "zfs",
 			Name: storagePoolName,
@@ -201,8 +200,7 @@ func ConfigureHost(settings HostSettings, remote Remote) error {
 		return errors.New("one or more units rely on the existing storage pool. Delete all units and try again")
 	}
 
-	timestamp := time.Now()
-	storagePoolName := settings.Name + "-" + timestamp.Format("20060102150405")
+	storagePoolName := settings.StoragePool.Name
 	storagePoolSize := settings.StoragePool.Size
 
 	currentStoragePoolName := settings.StoragePool.Name

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -64,6 +64,17 @@ func (vm Multipass) BraveBackendInit() error {
 		return err
 	}
 
+	// If a VM with this name already exists skip init - we will reuse the existing VM
+	_, err = shared.ExecCommandWReturn("multipass", "info", vm.Settings.Name)
+	if err == nil {
+		vm.Settings.Status = "active"
+		err = UpdateBraveSettings(vm.Settings)
+		if err != nil {
+			return errors.New("failed update settings" + err.Error())
+		}
+		return nil
+	}
+
 	if runtime.GOOS == "windows" {
 		err = shared.ExecCommand("multipass",
 			"set",
@@ -183,10 +194,6 @@ func (vm Multipass) BraveBackendInit() error {
 
 	fmt.Println("Installing required software ...")
 	time.Sleep(10 * time.Second)
-
-	timestamp := time.Now()
-	storagePoolName := vm.Settings.Profile + "-" + timestamp.Format("20060102150405")
-	vm.Settings.StoragePool.Name = storagePoolName
 
 	err = UpdateBraveSettings(vm.Settings)
 	if err != nil {

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -61,12 +61,9 @@ func DeleteStoragePool(lxdServer lxd.InstanceServer, name string) error {
 
 // SetActiveStoragePool pool assigns a profile with default storage
 func SetActiveStoragePool(lxdServer lxd.InstanceServer, name string) error {
-	username, err := getCurrentUsername()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
+	profileName := shared.BravetoolsVmName
 
-	profile, etag, err := lxdServer.GetProfile(username)
+	profile, etag, err := lxdServer.GetProfile(profileName)
 	if err != nil {
 		return errors.New("Unable to load profile: " + err.Error())
 	}
@@ -79,7 +76,7 @@ func SetActiveStoragePool(lxdServer lxd.InstanceServer, name string) error {
 
 	profile.Devices["root"] = device
 
-	err = lxdServer.UpdateProfile(username, profile.Writable(), etag)
+	err = lxdServer.UpdateProfile(profileName, profile.Writable(), etag)
 	if err != nil {
 		return errors.New("Failed to update profile with storage pool configuration: " + err.Error())
 	}

--- a/shared/constants.go
+++ b/shared/constants.go
@@ -1,5 +1,8 @@
 package shared
 
+// Name of Bravetools VM if not on Linux
+const BravetoolsVmName = "bravetools"
+
 const BraveHome = "/.bravetools"
 const BraveCertStore = BraveHome + "/certs"
 const BraveServerCertStore = BraveHome + "/servercerts"

--- a/shared/strings.go
+++ b/shared/strings.go
@@ -12,8 +12,8 @@ const REMOVELIN = `
 Looks like you're initialising an already configured Bravetools environment.
 
 You can manually cleanup your Bravetools LXD configuration using LXD CLI:				
-1. lxc profile delete $USER
-2. lxc storage delete bravetools
+1. lxc profile delete bravetools-$USER
+2. lxc storage delete bravetools-$USER
 3. lxc network delete bravetoolsbr0
 `
 

--- a/shared/strings.go
+++ b/shared/strings.go
@@ -12,9 +12,9 @@ const REMOVELIN = `
 Looks like you're initialising an already configured Bravetools environment.
 
 You can manually cleanup your Bravetools LXD configuration using LXD CLI:				
-1. lxc profile delete brave
-2. lxc storage delete brave-[timestamp]
-3. lxc network delete {$USER}br0
+1. lxc profile delete $USER
+2. lxc storage delete bravetools
+3. lxc network delete bravetoolsbr0
 `
 
 // REMOVEMP ..
@@ -24,6 +24,6 @@ Bravetools already initialised.
 To delete Bravetools:
 
 1. rm -r $HOME/.bravetools
-2. multipass delete brave
+2. multipass delete bravetools
 3. multipass purge"
 `


### PR DESCRIPTION
multipass VM will now be called "bravetools" to avoid potential collisions with existing VMs. In a multi-user scenario this bravetools VM will be shared between all users - `brave init` has been adjusted to check for existing VM.

The LXD bridge will also be shared and will be called "bravetoolsbr0".

Storage pool name is now same as LXD profile name (which is username), no longer has the timestamp. This aids discoverabiltiy in future.

Username cleaning has been removed due to strict limitations of LXD bridge names no longer being applicable.

Docs updated with latest changes.