### PR TITLE
Resource panic

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -987,9 +987,11 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 	}
 
 	// Assign static IP
-	err = ConfigDevice(lxdServer, unitName, "eth0", unitParams.IP)
-	if err = shared.CollectErrors(err, ctx.Err()); err != nil {
-		return errors.New("failed to set IP: " + err.Error())
+	if unitParams.IP != "" {
+		err = ConfigDevice(lxdServer, unitName, "eth0", unitParams.IP)
+		if err = shared.CollectErrors(err, ctx.Err()); err != nil {
+			return errors.New("failed to set IP: " + err.Error())
+		}
 	}
 
 	err = Stop(lxdServer, unitName)

--- a/platform/resources.go
+++ b/platform/resources.go
@@ -15,6 +15,11 @@ import (
 
 // CheckMemory checks if the LXD server host has sufficient RAM to deploy requested unit
 func CheckMemory(lxdServer lxd.InstanceServer, ramString string) error {
+	// If no ram limit requested, nothing to do
+	if ramString == "" {
+		return nil
+	}
+
 	resources, err := lxdServer.GetServerResources()
 	if err != nil {
 		//return errors.New(" " + err.Error())


### PR DESCRIPTION
Addresses https://github.com/bravetools/bravetools/issues/220

Changes:
- No longer panic when empty RAM string is provided.
- Skip network device config if no static IP requested

With this change it's possible to skip resource checks by providing an empty string "" to the values for RAM/CPU.