### PR TITLE
Embed version

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,16 +1,23 @@
 package main
 
 import (
+	_ "embed"
+
 	"log"
 
 	"github.com/bravetools/bravetools/commands"
+	"github.com/bravetools/bravetools/shared"
 )
+
+//go:embed VERSION
+var versionString string
 
 type cmdGlobal struct {
 	configPath string
 }
 
 func main() {
+	shared.Version = versionString
 
 	err := commands.BravetoolsCmd.Execute()
 	if err != nil && err.Error() != "" {

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -409,7 +409,7 @@ func (bh *BraveHost) UmountShare(unit string, target string) error {
 				"umount",
 				bh.Settings.Name+":"+path)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to unmount %q from multipass host: %s", path, err)
 			}
 
 			err = shared.ExecCommand("multipass", "exec", bh.Settings.Name, "rmdir", path)
@@ -630,7 +630,7 @@ func (bh *BraveHost) DeleteUnit(name string) error {
 		if (d["type"] == "disk") && strings.HasPrefix(deviceName, "brave_") {
 			err = bh.UmountShare(name, d["path"])
 			if err != nil {
-				log.Printf("failed to unmount %q from multipass host: %s\n", path.Join("/home/ubuntu/volumes/", deviceName), err)
+				log.Println(err)
 			}
 		}
 	}

--- a/shared/version.go
+++ b/shared/version.go
@@ -2,18 +2,11 @@ package shared
 
 import (
 	"fmt"
-	"path/filepath"
-	"runtime"
 )
 
-var (
-	_, b, _, _ = runtime.Caller(0)
-	basepath   = filepath.Dir(b)
-)
+var Version string
 
 // VersionString prints Bravetools version
 func VersionString() string {
-	buf, _ := ReadFile(filepath.Dir(basepath) + "/VERSION")
-
-	return fmt.Sprintf("Bravetools Version: %s", buf.String())
+	return fmt.Sprintf("Bravetools Version: %s", Version)
 }


### PR DESCRIPTION
Pre-built binaries for bravetools did not have version info built into them and consequently the version command would return nil. For example:
```sh
Bravetools Version: <nil>
```

This was caused by dynamic lookup of a version file which does not exist alongside the binary. Instead, it's better to embed the VERSION file into the binary so it's always available for lookup.

```sh
brave version
Bravetools Version: release-2.00
```