### PR TITLE
Bridge ip

### DIFF
--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1023,7 +1023,12 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 	if unitParams.IP != "" {
 		err = ConfigDevice(lxdServer, unitName, "eth0", unitParams.IP)
 		if err = shared.CollectErrors(err, ctx.Err()); err != nil {
-			return errors.New("failed to set IP: " + err.Error())
+			errMsg := fmt.Sprintf("failed to set IP: %s.\n", err.Error())
+			bridgeIP, _ := GetBravetoolsBridgeIP(lxdServer, bh.Settings.Network.Name)
+			if bridgeIP != "" {
+				errMsg = fmt.Sprintf("%s\nBravetools bridge is available at %s\n", errMsg, bridgeIP)
+			}
+			return errors.New(errMsg)
 		}
 	}
 

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -1444,3 +1444,12 @@ func GetLXDServerArch(lxdServer lxd.InstanceServer) (string, error) {
 
 	return serverStatus.Environment.KernelArchitecture, nil
 }
+
+func GetBravetoolsBridgeIP(lxdServer lxd.InstanceServer, bridgeName string) (string, error) {
+	network, _, err := lxdServer.GetNetwork(bridgeName)
+	if err != nil {
+		return "", err
+	}
+
+	return network.Config["ipv4.address"], nil
+}


### PR DESCRIPTION
In cases of multiple multipass users, the IP saved in ~/.bravetools/config.yml was inaccurate - although this doesn't seem to be used anywhere it is right to fix this.

A new function has been added to retrieve the IP address range covered by the `bravetools` bridge to retrieve the correct IP for the config file. This function is reused later to improve error messaging if an incorrect static IP address is requested for a unit during deployment, addressing https://github.com/bravetools/bravetools/issues/156.

