### PR TITLE
Fix dir type storage pool creation

### DIFF
--- a/platform/lxd.go
+++ b/platform/lxd.go
@@ -130,13 +130,17 @@ func initiateLxd(vm Lxd, whichLxc string) error {
 		return errors.New("failed to create LXD profile: " + err.Error())
 	}
 
-	err = shared.ExecCommand(
-		whichLxc,
+	storagePoolCmd := []string{
 		"storage",
 		"create",
 		vm.Settings.StoragePool.Name,
 		vm.Settings.StoragePool.Type,
-		"size="+vm.Settings.StoragePool.Size)
+	}
+	if vm.Settings.StoragePool.Type != "dir" {
+		storagePoolCmd = append(storagePoolCmd, "size="+vm.Settings.StoragePool.Size)
+	}
+
+	err = shared.ExecCommand(whichLxc, storagePoolCmd...)
 	if err != nil {
 		_ = shared.ExecCommand(whichLxc, "profile", "delete", vm.Settings.Profile)
 		return errors.New("failed to create storage pool: " + err.Error())

--- a/platform/multipass.go
+++ b/platform/multipass.go
@@ -81,7 +81,7 @@ func (vm Multipass) BraveBackendInit() error {
 			return errors.New("failed to create LXD profile: " + err.Error())
 		}
 
-		err = shared.ExecCommand("multipass",
+		storagePoolCmd := []string{
 			"exec",
 			vm.Settings.Name,
 			"--",
@@ -90,7 +90,12 @@ func (vm Multipass) BraveBackendInit() error {
 			"create",
 			vm.Settings.StoragePool.Name,
 			vm.Settings.StoragePool.Type,
-			"size="+vm.Settings.StoragePool.Size)
+		}
+		if vm.Settings.StoragePool.Type != "dir" {
+			storagePoolCmd = append(storagePoolCmd, "size="+vm.Settings.StoragePool.Size)
+		}
+
+		err = shared.ExecCommand("multipass", storagePoolCmd...)
 		if err != nil {
 			return errors.New("failed to create storage pool: " + err.Error())
 		}
@@ -311,7 +316,7 @@ EOF`
 		return errors.New("failed to create LXD profile: " + err.Error())
 	}
 
-	err = shared.ExecCommand("multipass",
+	storagePoolCmd := []string{
 		"exec",
 		vm.Settings.Name,
 		"--",
@@ -320,7 +325,12 @@ EOF`
 		"create",
 		vm.Settings.StoragePool.Name,
 		vm.Settings.StoragePool.Type,
-		"size="+vm.Settings.StoragePool.Size)
+	}
+	if vm.Settings.StoragePool.Type != "dir" {
+		storagePoolCmd = append(storagePoolCmd, "size="+vm.Settings.StoragePool.Size)
+	}
+
+	err = shared.ExecCommand("multipass", storagePoolCmd...)
 	if err != nil {
 		return errors.New("failed to create storage pool: " + err.Error())
 	}


### PR DESCRIPTION
When creating a dir type storage pool it is not possible to pass a size - attempting to do so causes an error.

This is a minimal fix that only adds the size portion of the command if the storage type is not dir.

Maybe in future we could explore using the `lxc` exec for just the bare minimum server setup and then completing the rest of the setup using the Go LXD client, but that's a bigger change to make and would need some testing.