### PR TITLE
Limit disk

### DIFF
--- a/docs/docs/bravefile.md
+++ b/docs/docs/bravefile.md
@@ -44,6 +44,7 @@ service:
     ram: "1GB"
     cpu: 4
     gpu: "no"
+    disk: "10GB"
 ```
 
 Running `brave build` followed by `brave deploy` on a ``Bravefile`` above, will pull a blank Alpine Edge system image for your CPU architecture, install python3, and make the container available on your network with 1GB of RAM and 4 CPUs. Image itself, will be sotred as `alpine-python3` and can be viewed by running `brave images`.
@@ -146,6 +147,7 @@ service:
     ram: "4GB"
     cpu: 4
     gpu: "no"
+    disk: "10GB"
 ```
 
 If you're deploying to a remote Bravetools host, you can append `<remote>:` to the `name` field. Note that you have to ensure that `profile` and `network` options are set and reflect the set up of your remote LXD instance.

--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -49,7 +49,7 @@ service:
     ram: 1GB
     cpu: 2
     gpu: "no"
-
+    disk: "10GB"
 ```
 
 This image will use Alpine Edge as its base and running `brave build` will install `python3` and `pip3` system packages using Alpine's `apk` package manager.

--- a/platform/host_api.go
+++ b/platform/host_api.go
@@ -1154,6 +1154,14 @@ func (bh *BraveHost) InitUnit(backend Backend, unitParams shared.Service) (err e
 		}
 	}
 
+	if unitParams.Resources.Disk != "" {
+		diskLimitConfig := map[string]string{"size": unitParams.Resources.Disk}
+		err = UpdateDevice(lxdServer, unitName, "root", diskLimitConfig)
+		if err != nil {
+			return fmt.Errorf("failed to apply disk limit: %s", err)
+		}
+	}
+
 	err = SetConfig(lxdServer, unitName, config)
 	if err = shared.CollectErrors(err, ctx.Err()); err != nil {
 		return errors.New("error configuring unit: " + err.Error())

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -292,6 +292,34 @@ func AddDevice(lxdServer lxd.InstanceServer, unitName string, devname string, de
 
 }
 
+func UpdateDevice(lxdServer lxd.InstanceServer, unitName string, deviceName string, deviceSettings map[string]string) error {
+	inst, etag, err := lxdServer.GetInstance(unitName)
+	if err != nil {
+		return errors.New("Error accessing unit: " + unitName)
+	}
+
+	currentSettings, ok := inst.Devices[deviceName]
+	if !ok {
+		return fmt.Errorf("device %q not found on unit %q", deviceName, unitName)
+	}
+
+	for k, v := range deviceSettings {
+		currentSettings[k] = v
+	}
+
+	op, err := lxdServer.UpdateInstance(unitName, inst.Writable(), etag)
+	if err != nil {
+		return errors.New("Errors updating unit configuration: " + unitName)
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return errors.New("Error updating unit " + unitName + " Error: " + err.Error())
+	}
+
+	return nil
+}
+
 // MountDirectory mounts local directory to unit
 func MountDirectory(lxdServer lxd.InstanceServer, sourcePath string, destUnit string, destPath string) error {
 

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -269,7 +269,7 @@ func DeleteDevice(lxdServer lxd.InstanceServer, name string, target string) (str
 	return source, nil
 }
 
-// AddDevice adds an external device to
+// AddDevice adds an external device to a unit with the given devSettings
 func AddDevice(lxdServer lxd.InstanceServer, unitName string, devname string, devSettings map[string]string) error {
 	inst, etag, err := lxdServer.GetInstance(unitName)
 	if err != nil {
@@ -292,6 +292,8 @@ func AddDevice(lxdServer lxd.InstanceServer, unitName string, devname string, de
 
 }
 
+// UpdateDevice updates the deviceSettings of an existing device - existing config remains unchanged unless
+// overwritten by a matching key in the provided deviceSettings
 func UpdateDevice(lxdServer lxd.InstanceServer, unitName string, deviceName string, deviceSettings map[string]string) error {
 	inst, etag, err := lxdServer.GetInstance(unitName)
 	if err != nil {

--- a/shared/bravefile.go
+++ b/shared/bravefile.go
@@ -62,9 +62,10 @@ type Postdeploy struct {
 
 // Resources defines resources allocated to service
 type Resources struct {
-	RAM string `yaml:"ram"`
-	CPU string `yaml:"cpu"`
-	GPU string `yaml:"gpu"`
+	RAM  string `yaml:"ram"`
+	CPU  string `yaml:"cpu"`
+	GPU  string `yaml:"gpu"`
+	Disk string `yaml:"disk"`
 }
 
 // Bravefile describes unit configuration
@@ -212,6 +213,9 @@ func (s *Service) Merge(service *Service) {
 	}
 	if s.Resources.RAM == "" {
 		s.Resources.RAM = service.Resources.RAM
+	}
+	if s.Resources.Disk == "" {
+		s.Resources.Disk = service.Resources.Disk
 	}
 	if len(s.Postdeploy.Copy) == 0 {
 		s.Postdeploy.Copy = append(s.Postdeploy.Copy, service.Postdeploy.Copy...)


### PR DESCRIPTION
This implements the disk limit feature suggested here:
https://github.com/bravetools/bravetools/issues/244

By adding an additional field to the service resources you can limit the amount of disk space that a container uses.
If left blank or omitted no limit will be applied, so this is backwards compatible.

According to the [this blog](https://stgraber.org/2016/03/26/lxd-2-0-resource-control-412/) disk limits will only work when using either ZFS or BTRFS as the  storage backend. This is the default for remotes initialised by bravetools itself, but remote backends initialised separately and then added to bravetools may have different storage backends.

```
service:
    name: example-service
    resources:
        ram: 4GB
        cpu: 4
        disk: 2GB
```