### PR TITLE
Fix non snap lxd

### DIFF
--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -21,7 +21,7 @@ type Remote struct {
 	Protocol   string `json:"protocol"`
 	Public     bool   `json:"public"`
 	Profile    string `json:"profile"`
-	Network    string `JSON:"network"`
+	Network    string `json:"network"`
 	Storage    string `json:"storage"`
 	key        string
 	cert       string

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -21,7 +21,7 @@ type Remote struct {
 	Protocol   string `json:"protocol"`
 	Public     bool   `json:"public"`
 	Profile    string `json:"profile"`
-	Network    string `JSON:"NETwork"`
+	Network    string `JSON:"network"`
 	Storage    string `json:"storage"`
 	key        string
 	cert       string

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -21,7 +21,7 @@ type Remote struct {
 	Protocol   string `json:"protocol"`
 	Public     bool   `json:"public"`
 	Profile    string `json:"profile"`
-	Network    string `json:"network"`
+	Network    string `JSON:"NETwork"`
 	Storage    string `json:"storage"`
 	key        string
 	cert       string
@@ -35,7 +35,15 @@ func NewBravehostRemote(settings HostSettings) Remote {
 	switch settings.BackendSettings.Type {
 	case "lxd":
 		protocol = "unix"
-		url = "/var/snap/lxd/common/lxd/unix.socket"
+	
+		//Check which LXC binary is present, and set the url accordingly - JVB
+		_, whichLxc, _ := lxdCheck(Lxd{&settings})
+
+		if strings.Contains("/snap/",whichLxc) {
+			url = "/var/snap/lxd/common/lxd/unix.socket"
+		} else {
+			url = "/var/lib/lxd/unix.socket"
+		}
 	default:
 		protocol = "lxd"
 		url = "https://" + settings.BackendSettings.Resources.IP + ":8443"


### PR DESCRIPTION
Perhaps not the most elegant solution, and only tested on my Debian 12 system to build the "template" image, this PR looks at the current location of the installed lxc binary and either uses the previously hard-coded path for the "unix.socket" file or if snap is not detected uses the location that is present on my system where LXD has been installed by apt.

I will continue to test as well as work on completing the Debian packaging, but this at least unblocks my use case for now and I hope is helpful to others.
