### PR TITLE
Remote base image server docs

### DIFF
--- a/docs/docs/remotes.md
+++ b/docs/docs/remotes.md
@@ -110,53 +110,6 @@ When a new remote is added, its configuration is stored in `~/.bravetools/remote
 
 `profile` and `network` parameters refer to LXD profile and bridge on your remote respectively. You may need to alter these values, depending on your remote set up and manually edit `profile` and `network` fields to reflect your remote LXD configuration.
 
-## Configuring Bravetools to use Remotes for image builds
-
-By default, Bravetools uses a `local` remote for an image build. On Mac/Windows, this is a Multipass VM, whilst on Linux host this is your local LXD server. Sometimes, it may be desirable to use a remote LXD server to cary out Image builds. For example, if your remote has a different CPU architecture (arm64 vs x86) or has more allocated resources.
-
-Bravetools remote backend can be set in the global configuration file `~/.bravetools/config.yml` by setting the `remote` field to the name of one of your added remotes.
-
-```yaml
-name: user
-trust: user
-profile: user
-storage:
-  type: zfs
-  name: user-20220915121119
-  size: 98GB
-network:
-  name: userbr0
-  ip: 10.57.220.1
-backendsettings:
-  type: multipass
-  resources:
-    name: user
-    os: bionic
-    cpu: "2"
-    ram: 4GB
-    hd: 100GB
-    ip: 192.168.64.60
-status: active
-remote: local
-```
-
-Next time you run `brave build`, Bravetools will execute Bravefile instructions on the remote LXD server.
-
-## Deploying Units to Remotes
-
-To deploy an image to a specific remote, you can simply append the remote name to your target Unit name either on the command line or in the ``service`` section of your ``Bravefile``.
-
-```
-brave deploy brave-base-alpine-edge-1.0 --name myremote:test --port 1234:1234
-```
-
-## Manipulating Units on Remotes
-
-Basic Bravetools commands such as `brave start`, `brave stop`, and `brave remove` can access both local and remote units. If remote name is not appended to the unit name, Bravetools will assume that the unit is running on a `local` remote. To interact with a unit on a remote LXD server, simply append <remote>: to the unit name:
-
-```bash
-brave start myremote:test
-```
 
 ## Configurable base image servers
 
@@ -188,3 +141,53 @@ base:
 service:
   name: example-container
 ```
+
+
+## Deploying Units to Remotes
+
+To deploy an image to a specific remote, you can simply append the remote name to your target Unit name either on the command line or in the ``service`` section of your ``Bravefile``.
+
+```
+brave deploy brave-base-alpine-edge-1.0 --name myremote:test --port 1234:1234
+```
+
+## Manipulating Units on Remotes
+
+Basic Bravetools commands such as `brave start`, `brave stop`, and `brave remove` can access both local and remote units. If remote name is not appended to the unit name, Bravetools will assume that the unit is running on a `local` remote. To interact with a unit on a remote LXD server, simply append <remote>: to the unit name:
+
+```bash
+brave start myremote:test
+```
+
+
+## Configuring Bravetools to use Remotes for image builds
+
+By default, Bravetools uses a `local` remote for an image build. On Mac/Windows, this is a Multipass VM, whilst on Linux host this is your local LXD server. Sometimes, it may be desirable to use a remote LXD server to cary out Image builds. For example, if your remote has a different CPU architecture (arm64 vs x86) or has more allocated resources.
+
+Bravetools remote backend can be set in the global configuration file `~/.bravetools/config.yml` by setting the `remote` field to the name of one of your added remotes.
+
+```yaml
+name: user
+trust: user
+profile: user
+storage:
+  type: zfs
+  name: user-20220915121119
+  size: 98GB
+network:
+  name: userbr0
+  ip: 10.57.220.1
+backendsettings:
+  type: multipass
+  resources:
+    name: user
+    os: bionic
+    cpu: "2"
+    ram: 4GB
+    hd: 100GB
+    ip: 192.168.64.60
+status: active
+remote: local
+```
+
+Next time you run `brave build`, Bravetools will execute Bravefile instructions on the remote LXD server.

--- a/docs/docs/remotes.md
+++ b/docs/docs/remotes.md
@@ -157,3 +157,34 @@ Basic Bravetools commands such as `brave start`, `brave stop`, and `brave remove
 ```bash
 brave start myremote:test
 ```
+
+## Configurable base image servers
+
+### Default base image server
+Canonical has deployed their own images server that hosts images from other distributions (including alpine, centOS, Debian etc...). This server is available at https://images.lxd.canonical.com. The one downside to this image repository is that it does not ship Ubuntu server images, only Ubuntu desktop images. If you need Ubuntu server images they are available at a different repository: https://cloud-images.ubuntu.com/releases.
+
+You can configure bravetools to use Ubuntu server images by editing or adding the config option 'public_image_remote' in ~/.bravetools/config.yml:
+```
+public_image_remote: https://cloud-images.ubuntu.com/minimal/releases/
+```
+
+Alternatively you can follow the instructions below to add an "ubuntu" remote and use that remote when specifying your base image in your Bravefile.
+
+### Adding additional image servers
+It's possible to add remote image server as bravetools remotes and explicitly select which remote to use to retrieve the base image in the Bravefile instead of adjusting the default in bravetools config. This can be useful if you want to use a remote by default except for certain images - for example, using https://images.lxd.canonical.com for most images but https://cloud-images.ubuntu.com/releases for cloud Ubuntu server images.
+
+For example, first add a remote named "ubuntu" for Ubuntu server cloud images:
+```sh
+brave remote add --protocol simplestreams --public ubuntu https://cloud-images.ubuntu.com/releases/                     
+```
+
+Then in the Bravefile specify that this remote is to be used to retrieve the base image:
+```yaml
+image: example-image/v1.0
+
+base:
+  image: ubuntu:20.04
+
+service:
+  name: example-container
+```


### PR DESCRIPTION
With the end of LXD access to https://images.linuxcontainers.org, to be replaced by https://images.lxd.canonical.com, it is important to highlight the capabilities bravetools has to handle public simplestreams remotes. Using these, users of bravetools can have multiple image servers available to them at once and specify which they want to use in the Bravefile.


The is particularly useful for using the ubuntu cloud server images which are not available in the current default image remote, instead being available at https://cloud-images.ubuntu.com/releases/

This also enables users to easily use the [minimal Ubuntu cloud images](https://cloud-images.ubuntu.com/minimal/releases/) easily as well.

Currently this all relies on users manually adding these remotes, but we can consider streamlining this process by creating some default remotes during `brave init`