### PR TITLE
Upgrade multipass host OS

### DIFF
--- a/platform/host.go
+++ b/platform/host.go
@@ -132,7 +132,7 @@ func SetupHostConfiguration(params HostConfig, userHome string, publicImageServe
 			Type: "multipass",
 			Resources: BackendResources{
 				Name: hostName,
-				OS:   "bionic",
+				OS:   "noble",
 				CPU:  "2",
 				RAM:  params.Ram,
 				HD:   params.Storage + "GB",


### PR DESCRIPTION
Update multipass host OS installed during brave init from bionic to noble - binoic is no longer in support and so is not available for download through multipass. Noble will be supported until June 2029.